### PR TITLE
#17: toctoc testing helper module (closes #17)

### DIFF
--- a/toctoc/core/src/test/scala/io.buildo.toctoc/core/authentication/InMemoryAuthenticationDomain.scala
+++ b/toctoc/core/src/test/scala/io.buildo.toctoc/core/authentication/InMemoryAuthenticationDomain.scala
@@ -1,0 +1,43 @@
+package io.buildo.toctoc
+package core
+package authentication
+
+import cats.Applicative
+import cats.syntax.all._
+
+final class InMemoryAuthenticationDomain[F[_]: Applicative, C <: Credential](
+  private val credentials: Map[C, Subject] = Map.empty,
+) extends AuthenticationDomain[F, C] {
+
+  override def authenticate(
+    c: C,
+  ): F[Either[AuthenticationError, (AuthenticationDomain[F, C], Subject)]] =
+    credentials
+      .get(c)
+      .map((this, _))
+      .toRight(AuthenticationError.InvalidCredential)
+      .pure[F]
+      .widen
+
+  override def register(
+    s: Subject,
+    c: C,
+  ): F[Either[AuthenticationError, AuthenticationDomain[F, C]]] =
+    new InMemoryAuthenticationDomain(credentials + (c -> s))
+      .asRight[AuthenticationError]
+      .pure[F]
+      .widen
+
+  override def unregister(s: Subject): F[Either[AuthenticationError, AuthenticationDomain[F, C]]] =
+    new InMemoryAuthenticationDomain(credentials.filterNot {
+      case (_, v) => v == s
+    }).asRight[AuthenticationError]
+      .pure[F]
+      .widen
+
+  override def unregister(c: C): F[Either[AuthenticationError, AuthenticationDomain[F, C]]] =
+    new InMemoryAuthenticationDomain(credentials - c)
+      .asRight[AuthenticationError]
+      .pure[F]
+      .widen
+}

--- a/toctoc/core/src/test/scala/io.buildo.toctoc/core/authentication/InMemoryAuthenticationDomain.scala
+++ b/toctoc/core/src/test/scala/io.buildo.toctoc/core/authentication/InMemoryAuthenticationDomain.scala
@@ -5,7 +5,7 @@ package authentication
 import cats.Applicative
 import cats.syntax.all._
 
-final class InMemoryAuthenticationDomain[F[_]: Applicative, C <: Credential](
+final class InMemoryAuthenticationDomain[F[_]: Applicative, C](
   private val credentials: Map[C, Subject] = Map.empty,
 ) extends AuthenticationDomain[F, C] {
 


### PR DESCRIPTION
Closes #17

In memory test double for supporting flow testing.

## Test Plan

⚠️ Untested code, use with care.

See https://github.com/buildo/backend/issues/28