### PR TITLE
#9: Explicitly use a configurable schema name for slick tables (closes #9)

### DIFF
--- a/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/login/MySqlSlickLoginAuthenticationDomain.scala
+++ b/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/login/MySqlSlickLoginAuthenticationDomain.scala
@@ -19,12 +19,14 @@ import scala.concurrent.Future
 class MySqlSlickLoginAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
   db: Database,
   tableName: String = "login_auth_domain",
+  schemaName: Option[String] = None,
 )(
   implicit F: Sync[F],
 ) extends LoginDomain[F]
     with BCryptHashing {
 
-  class LoginTable(tag: Tag) extends Table[(Int, String, String, String)](tag, tableName) {
+  class LoginTable(tag: Tag)
+      extends Table[(Int, String, String, String)](tag, schemaName, tableName) {
     def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
     def ref = column[String]("ref")
     def username = column[String]("username", O.Length(255))

--- a/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/token/MySqlSlickAccessTokenAuthenticationDomain.scala
+++ b/toctoc/slickMySql/src/main/scala/io.buildo.toctoc/slick/authentication/token/MySqlSlickAccessTokenAuthenticationDomain.scala
@@ -19,11 +19,13 @@ import java.time.Instant
 class MySqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
   db: Database,
   tableName: String = "access_token_auth_domain",
+  schemaName: Option[String] = None,
 )(
   implicit F: Sync[F],
 ) extends AccessTokenDomain[F] {
 
-  class AccessTokenTable(tag: Tag) extends Table[(Int, String, String, Instant)](tag, tableName) {
+  class AccessTokenTable(tag: Tag)
+      extends Table[(Int, String, String, Instant)](tag, schemaName, tableName) {
     def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
     def ref = column[String]("ref")
     def token = column[String]("token", O.Length(255))

--- a/toctoc/slickPostgreSql/src/main/scala/io.buildo.toctoc/slick/authentication/login/PostgreSqlSlickLoginAuthenticationDomain.scala
+++ b/toctoc/slickPostgreSql/src/main/scala/io.buildo.toctoc/slick/authentication/login/PostgreSqlSlickLoginAuthenticationDomain.scala
@@ -19,12 +19,14 @@ import scala.concurrent.Future
 class PostgreSqlSlickLoginAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
   db: Database,
   tableName: String = "login_auth_domain",
+  schemaName: Option[String] = None,
 )(
   implicit F: Sync[F],
 ) extends LoginDomain[F]
     with BCryptHashing {
 
-  class LoginTable(tag: Tag) extends Table[(Int, String, String, String)](tag, tableName) {
+  class LoginTable(tag: Tag)
+      extends Table[(Int, String, String, String)](tag, schemaName, tableName) {
     def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
     def ref = column[String]("ref")
     def username = column[String]("username")

--- a/toctoc/slickPostgreSql/src/main/scala/io.buildo.toctoc/slick/authentication/token/PostgreSqlSlickAccessTokenAuthenticationDomain.scala
+++ b/toctoc/slickPostgreSql/src/main/scala/io.buildo.toctoc/slick/authentication/token/PostgreSqlSlickAccessTokenAuthenticationDomain.scala
@@ -19,15 +19,13 @@ import java.time.Instant
 class PostgreSqlSlickAccessTokenAuthenticationDomain[F[_]: FutureLift[?[_], Future]](
   db: Database,
   tableName: String = "access_token_auth_domain",
+  schemaName: Option[String] = None,
 )(
   implicit F: Sync[F],
 ) extends AccessTokenDomain[F] {
 
   class AccessTokenTable(tag: Tag)
-      extends Table[(Int, String, String, Instant)](
-        tag,
-        tableName,
-      ) {
+      extends Table[(Int, String, String, Instant)](tag, schemaName, tableName) {
     def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
     def ref = column[String]("ref")
     def token = column[String]("token")

--- a/toctoc/slickPostgreSql/src/test/scala/io.buildo.toctoc/slick/authentication/test/PostgreSqlSlickLoginAuthenticationDomainFlowSpec.scala
+++ b/toctoc/slickPostgreSql/src/test/scala/io.buildo.toctoc/slick/authentication/test/PostgreSqlSlickLoginAuthenticationDomainFlowSpec.scala
@@ -22,11 +22,13 @@ class PostgreSqlSlickLoginAuthenticationDomainFlowSpec
     with EitherValues
     with Matchers {
 
+  val schemaName = Some("public")
   val loginTableName = "login"
   val tokenTableName = "token"
 
   val db = Database.forConfig("db")
-  val loginAuthDomain = new PostgreSqlSlickLoginAuthenticationDomain[IO](db, loginTableName)
+  val loginAuthDomain =
+    new PostgreSqlSlickLoginAuthenticationDomain[IO](db, loginTableName, schemaName)
   val accessTokenAuthDomain =
     new PostgreSqlSlickAccessTokenAuthenticationDomain[IO](db, tokenTableName)
 


### PR DESCRIPTION
Closes #9

## Test Plan

Modified current tests by explicitly specifying the `public` schema.
