### PR TITLE
#38: Revise implementation of recursivelyListFiles (closes #38)

### DIFF
--- a/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/Metarpheus.scala
+++ b/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/Metarpheus.scala
@@ -8,18 +8,9 @@ import scala.meta.internal.io.PlatformFileIO
 
 object Metarpheus {
 
-  def recursivelyListFiles(target: AbsolutePath): List[AbsolutePath] = {
-    if (target.isDirectory) {
-      val dirContent = PlatformFileIO.listFiles(target).iterator.toList
-      dirContent ++ dirContent.filter(_.isDirectory).flatMap(recursivelyListFiles)
-    } else {
-      List(target)
-    }
-  }
-
   def run(paths: List[String], config: Config): intermediate.API = {
     val files = paths
-      .flatMap(path => recursivelyListFiles(AbsolutePath(path)))
+      .flatMap(path => PlatformFileIO.listAllFilesRecursively(AbsolutePath(path)))
       .filter(_.toString.endsWith(".scala"))
     val parsed = files.map(File(_).parse[Source].get)
     extractors


### PR DESCRIPTION
Closes #38

`PlatformFileIO` now has a method `listAllFilesRecursively`, so I guess we can just use that instead of `listFiles` + recursion?

## Test Plan

### tests performed

I've run it on a project by swapping the newly-compiled `index.js` file for the one in `node_modules` to check it finds the same files.