### PR TITLE
#74: Fix parametric types and json codecs names (closes #74)

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Cli.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Cli.scala
@@ -38,7 +38,8 @@ object Cli {
       case Some(c) => {
         c.`package`.split(".").toList match {
           case Nil => throw new Exception("Cannot create routes with empty package")
-          case head :: tail => Util.createFiles(c.from, c.to, NonEmptyList(head, tail), c.includeHttp4sModels)
+          case head :: tail =>
+            Util.createFiles(c.from, c.to, NonEmptyList(head, tail), c.includeHttp4sModels)
         }
       }
       case _ =>

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Cli.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Cli.scala
@@ -36,7 +36,7 @@ object Cli {
 
     OParser.parse(parser, args, CliConfig()) match {
       case Some(c) => {
-        c.`package`.split(".").toList match {
+        c.`package`.split("\\.").toList match {
           case Nil => throw new Exception("Cannot create routes with empty package")
           case head :: tail =>
             Util.createFiles(c.from, c.to, NonEmptyList(head, tail), c.includeHttp4sModels)

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
@@ -7,7 +7,8 @@ import scala.meta._
 import cats.data.NonEmptyList
 
 object Meta {
-  val codecsImplicits = (routes: List[TapiroRoute]) => routes.flatMap {
+  val codecsImplicits = (routes: List[TapiroRoute]) =>
+    routes.flatMap {
       case TapiroRoute(route, errorValues) =>
         errorValues.map(_.name) ++
           route.body.map(b => typeNameString(b.tpe)) :+
@@ -29,5 +30,6 @@ object Meta {
     }
 
   def packageFromList(`package`: NonEmptyList[String]): Term.Ref =
-    `package`.tail.foldLeft[Term.Ref](Term.Name(`package`.head))((acc, n) => Term.Select(acc, Term.Name(n)))
+    `package`.tail
+      .foldLeft[Term.Ref](Term.Name(`package`.head))((acc, n) => Term.Select(acc, Term.Name(n)))
 }

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
@@ -10,15 +10,16 @@ object Meta {
   val codecsImplicits = (routes: List[TapiroRoute]) =>
     routes.flatMap {
       case TapiroRoute(route, errorValues) =>
-        errorValues.map(_.name) ++
-          route.body.map(b => typeNameString(b.tpe)) :+
-          typeNameString(route.returns)
-    }.distinct.map(stringToImplicitParam)
+        errorValues.map(m => MetarpheusType.Name(m.name)) ++
+          route.body.map(_.tpe) :+
+          route.returns
+    }.distinct.map(toImplicitParam)
 
-  private[this] val stringToImplicitParam = (name: String) => {
-    val paramName = Term.Name(s"${name.head.toLower}${name.tail}")
-    val nameType = Type.Name(name)
-    param"implicit ${paramName}: JsonCodec[$nameType]"
+  private[this] val toImplicitParam = (`type`: MetarpheusType) => {
+    val typeName = typeNameString(`type`)
+    val paramName = Term.Name(s"${typeName.head.toLower}${typeName.tail}")
+    val paramType = toScalametaType(`type`)
+    param"implicit ${paramName}: JsonCodec[$paramType]"
   }
 
   val typeName = (`type`: MetarpheusType) => Type.Name(typeNameString(`type`))

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
@@ -29,6 +29,12 @@ object Meta {
       case MetarpheusType.Name(name)     => name
     }
 
+  val toScalametaType: MetarpheusType => Type = {
+    case MetarpheusType.Apply(name, args) =>
+      Type.Apply(Type.Name(name), args.map(toScalametaType).toList)
+    case MetarpheusType.Name(name) => Type.Name(name)
+  }
+
   def packageFromList(`package`: NonEmptyList[String]): Term.Ref =
     `package`.tail
       .foldLeft[Term.Ref](Term.Name(`package`.head))((acc, n) => Term.Select(acc, Term.Name(n)))

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -45,8 +45,8 @@ object TapirMeta {
     q"val ${Pat.Var(Term.Name(route.route.name.tail.mkString))}: ${endpointType(route.route)} = ${endpointImpl(route)}"
 
   private[this] val endpointType = (route: Route) => {
-    val returnType = typeName(route.returns)
-    val argsList = route.params.map(p => typeName(p.tpe)) ++
+    val returnType = toScalametaType(route.returns)
+    val argsList = route.params.map(p => toScalametaType(p.tpe)) ++
       route.body.map(b => typeName(b.tpe))
     val argsType = argsList match {
       case Nil         => Type.Name("Unit")

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -47,13 +47,13 @@ object TapirMeta {
   private[this] val endpointType = (route: Route) => {
     val returnType = toScalametaType(route.returns)
     val argsList = route.params.map(p => toScalametaType(p.tpe)) ++
-      route.body.map(b => typeName(b.tpe))
+      route.body.map(b => toScalametaType(b.tpe))
     val argsType = argsList match {
       case Nil         => Type.Name("Unit")
       case head :: Nil => head
       case l           => Type.Tuple(l)
     }
-    val error = Type.Name(route.error.map(typeNameString).getOrElse("String"))
+    val error = route.error.map(toScalametaType).getOrElse(Type.Name("String"))
     t"Endpoint[$argsType, $error, $returnType, Nothing]"
   }
 
@@ -86,7 +86,7 @@ object TapirMeta {
   private[this] val withBody = (endpoint: meta.Term, tpe: MetarpheusType) => {
     Term.Apply(
       Term.Select(endpoint, Term.Name("in")),
-      List(Term.ApplyType(Term.Name("jsonBody"), List(Type.Name(typeNameString(tpe))))),
+      List(Term.ApplyType(Term.Name("jsonBody"), List(toScalametaType(tpe)))),
     ),
   }
 
@@ -120,7 +120,7 @@ object TapirMeta {
       List(
         Term.ApplyType(
           Term.Name("jsonBody"),
-          List(typeName(returnType)),
+          List(toScalametaType(returnType)),
         ),
       ),
     )
@@ -131,7 +131,7 @@ object TapirMeta {
         Term.Select(endpoint, Term.Name("in")),
         List(
           Term.Apply(
-            Term.ApplyType(Term.Name("query"), List(Type.Name(typeNameString(param.tpe)))),
+            Term.ApplyType(Term.Name("query"), List(toScalametaType(param.tpe))),
             List(Lit.String(param.name.getOrElse(typeNameString(param.tpe)))),
           ),
         ),

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Util.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Util.scala
@@ -1,7 +1,13 @@
 package io.buildo.tapiro
 
 import io.buildo.metarpheus.core.{Config, Metarpheus}
-import io.buildo.metarpheus.core.intermediate.{Route, RouteSegment, TaggedUnion, CaseEnum, CaseClass}
+import io.buildo.metarpheus.core.intermediate.{
+  CaseClass,
+  CaseEnum,
+  Route,
+  RouteSegment,
+  TaggedUnion,
+}
 import scala.meta._
 import scala.util.control.NonFatal
 import java.nio.file.Paths
@@ -16,7 +22,12 @@ case class TapiroRoute(route: Route, errorValues: List[TaggedUnion.Member])
 object Util {
   import Formatter.format
 
-  def createFiles(from: String, to: String, `package`: NonEmptyList[String], includeHttp4sModels: Boolean) = {
+  def createFiles(
+    from: String,
+    to: String,
+    `package`: NonEmptyList[String],
+    includeHttp4sModels: Boolean,
+  ) = {
     val meta = Metarpheus.run(List(from), Config(Set.empty))
     val routes: List[TapiroRoute] = meta.routes.map { route =>
       val errorValues: List[TaggedUnion.Member] = routeErrorValues(route, meta.models)
@@ -27,9 +38,9 @@ object Util {
         route => route.route.route.collect { case RouteSegment.String(str) => str }.head,
       )
     val modelsPackages = meta.models.map {
-      case c: CaseClass => c.`package`
-      case c: CaseEnum => c.`package` 
-      case t: TaggedUnion => t.`package` 
+      case c: CaseClass   => c.`package`
+      case c: CaseEnum    => c.`package`
+      case t: TaggedUnion => t.`package`
     }.collect {
       case head :: tail => NonEmptyList(head, tail)
     }
@@ -51,7 +62,7 @@ object Util {
     endpointsName: String,
     routes: List[TapiroRoute],
     `package`: NonEmptyList[String],
-    modelsPackages: List[NonEmptyList[String]]
+    modelsPackages: List[NonEmptyList[String]],
   ): String = {
     format(
       TapirMeta.`class`(


### PR DESCRIPTION
Closes #74

I've changed code generation to replace the use of `typeName` (which gets the name of a Metarpheus type) with a new function `toScalametaType` which instead converts the type back into a Scalameta type. This means that we get parametric types in endpoint types and JSON codecs.

For instance, before this we had:

    val read: Endpoint[Id, BotReadError, BotSummary, Nothing]
    ...
    id: JsonCodec[Id],
    ...
    .out(jsonBody[Id])

and now:

    val read: Endpoint[Id[Bot], BotReadError, BotSummary, Nothing]
    ...
    id: JsonCodec[Id[Bot]],
    ...
    .out(jsonBody[Id[Bot]])

## Test Plan

Continued testing on our internal project, this fixes some compilation errors.