### PR TITLE
#73: Fix tapiro JsonCodec for post body (closes #73)

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
@@ -11,6 +11,7 @@ object Meta {
     routes.flatMap {
       case TapiroRoute(route, errorValues) =>
         errorValues.map(m => MetarpheusType.Name(m.name)) ++
+          route.params.map(_.tpe) ++
           route.body.map(_.tpe) :+
           route.returns
     }.distinct.map(toImplicitParam)


### PR DESCRIPTION
Closes #73

## Test Plan

tested locally, the problem was there also for query parameters

<img width="1058" alt="Screenshot 2019-12-20 at 15 57 13" src="https://user-images.githubusercontent.com/2476080/71263060-728e5b80-2341-11ea-99f2-d2cc9a304353.png">


### tests performed

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
