### PR TITLE
#86: Get requests with no query parameters should not have `.tupled` (closes #86)

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
@@ -48,10 +48,10 @@ object Http4sMeta {
       val controllersName = Term.Select(Term.Name("controller"), name)
       val controllerContent =
         if (route.method == "post") Some(controllersName)
-        else if (route.method == "get")
-          if (route.params.length >= 1) Some(Term.Select(Term.Eta(controllersName), Term.Name("tupled")))
-          else Some(controllersName)
-        else None
+        else if (route.method == "get") {
+          if (route.params.isEmpty) Some(controllersName)
+          else Some(Term.Select(Term.Eta(controllersName), Term.Name("tupled")))
+        } else None
       controllerContent.map { content =>
         val toRoutes = Term.Apply(Term.Select(endpointsName, Term.Name("toRoutes")), List(content))
         q"val ${Pat.Var(name)} = $toRoutes"

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
@@ -47,8 +47,10 @@ object Http4sMeta {
       val endpointsName = Term.Select(Term.Name("endpoints"), name)
       val controllersName = Term.Select(Term.Name("controller"), name)
       val controllerContent =
-        if (route.method == "get") Some(Term.Select(Term.Eta(controllersName), Term.Name("tupled")))
-        else if (route.method == "post") Some(controllersName)
+        if (route.method == "post") Some(controllersName)
+        else if (route.method == "get")
+          if (route.params.length >= 1) Some(Term.Select(Term.Eta(controllersName), Term.Name("tupled")))
+          else Some(controllersName)
         else None
       controllerContent.map { content =>
         val toRoutes = Term.Apply(Term.Select(endpointsName, Term.Name("toRoutes")), List(content))


### PR DESCRIPTION
Closes #86

## Test Plan

locally

![image](https://user-images.githubusercontent.com/2476080/71374214-33b70a80-25ba-11ea-9080-29ecc2b01f2c.png)


### tests performed

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
