### PR TITLE
#88: Errors should have proper json encoder instead of string (closes #88)

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
@@ -13,6 +13,7 @@ object Meta {
         val params: List[MetarpheusType] = route.params.map(_.tpe)
         errorValues.map(m => MetarpheusType.Name(m.name)) ++
           (if (route.method == "post") params else Nil) ++
+          route.error ++
           route.body.map(_.tpe) :+
           route.returns
     }.distinct.map(toJsonCodec)

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -95,8 +95,9 @@ object TapirMeta {
       Term.Apply(
         Term.Select(endpoints, Term.Name("errorOut")),
         List(
-          if (errorValues.isEmpty) Term.Name("stringBody")
-          else listErrors(errorValues, errorName),
+          if (errorValues.isEmpty && errorName == "String") Term.Name("stringBody")
+          else if (errorValues.isEmpty && errorName != "String") Term.ApplyType(Term.Name("jsonBody"), List(Type.Name(errorName)))
+          else listErrors(errorValues, errorName)
         ),
       )
 


### PR DESCRIPTION

Closes #88

## Test Plan

### tests performed

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
