### PR TITLE
#93: Tapiro sealed traits json codecs compilation error (closes #93 #82)

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
@@ -1,6 +1,6 @@
 package io.buildo.tapiro
 
-import io.buildo.metarpheus.core.intermediate.{Type => MetarpheusType}
+import io.buildo.metarpheus.core.intermediate.{TaggedUnion, Type => MetarpheusType}
 
 import scala.meta._
 
@@ -8,34 +8,40 @@ import cats.data.NonEmptyList
 
 object Meta {
   val codecsImplicits = (routes: List[TapiroRoute]) => {
-    val jsonCodecs = routes.flatMap {
-      case TapiroRoute(route, errorValues) =>
+    val jsonCodecs = (routes.flatMap {
+      case TapiroRoute(route, error) =>
         val params: List[MetarpheusType] = route.params.map(_.tpe)
-        errorValues.map(m => MetarpheusType.Name(m.name)) ++
-          (if (route.method == "post") params else Nil) ++
-          route.error ++
+        ((if (route.method == "post") params else Nil) ++
+          (error match {
+            case TapiroRouteError.OtherError(t) => List(t)
+            case _                              => Nil
+          }) ++
           route.body.map(_.tpe) :+
-          route.returns
-    }.distinct.map(toJsonCodec)
+          route.returns)
+    }.distinct
+      .map(toScalametaType)
+      ++ taggedUnionErrorMembers(routes))
+      .map(t => t"JsonCodec[$t]")
     val plainCodecs = routes.flatMap {
       case TapiroRoute(route, _) =>
         (if (route.method == "get") route.params.map(_.tpe) else Nil)
-    }.distinct.map(toPlainCodec)
-    jsonCodecs ++ plainCodecs
+    }.distinct.map(t => t"PlainCodec[${toScalametaType(t)}]")
+    val codecs = jsonCodecs ++ plainCodecs
+    codecs.zipWithIndex.map(toImplicitParam.tupled)
   }
 
-  private[this] val toJsonCodec = (`type`: MetarpheusType) => {
-    val typeName = typeNameString(`type`)
-    val paramName = Term.Name(s"${typeName.head.toLower}${typeName.tail}JsonCodec")
-    val paramType = toScalametaType(`type`)
-    param"implicit ${paramName}: JsonCodec[$paramType]"
+  private[this] val taggedUnionErrorMembers = (routes: List[TapiroRoute]) => {
+    val taggedUnions = routes.collect {
+      case TapiroRoute(_, TapiroRouteError.TaggedUnionError(tu)) => tu
+    }.distinct
+    taggedUnions.flatMap { taggedUnion =>
+      taggedUnion.values.map(taggedUnionMemberType(taggedUnion))
+    }
   }
 
-  private[this] val toPlainCodec = (`type`: MetarpheusType) => {
-    val typeName = typeNameString(`type`)
-    val paramName = Term.Name(s"${typeName.head.toLower}${typeName.tail}PlainCodec")
-    val paramType = toScalametaType(`type`)
-    param"implicit ${paramName}: PlainCodec[$paramType]"
+  private[this] val toImplicitParam = (paramType: Type, index: Int) => {
+    val paramName = Term.Name(s"codec$index")
+    param"implicit $paramName: $paramType"
   }
 
   val typeName = (`type`: MetarpheusType) => Type.Name(typeNameString(`type`))
@@ -51,6 +57,13 @@ object Meta {
       Type.Apply(Type.Name(name), args.map(toScalametaType).toList)
     case MetarpheusType.Name(name) => Type.Name(name)
   }
+
+  val taggedUnionMemberType = (taggedUnion: TaggedUnion) =>
+    (member: TaggedUnion.Member) => {
+      if (member.params.isEmpty)
+        Type.Singleton(Term.Select(Term.Name(taggedUnion.name), Term.Name(member.name)))
+      else Type.Select(Term.Name(taggedUnion.name), Type.Name(member.name)),
+    }
 
   def packageFromList(`package`: NonEmptyList[String]): Term.Ref =
     `package`.tail


### PR DESCRIPTION
Closes #93 #82 

We now generate correct types for tagged union members in JSON codecs.

In the implicits I'm not generating the parameter for the codec for the sealed trait (because we're not using it currently) but only those for the case classes and objects that extend it.

Closes also #82 because name generation was getting a little bit more complicated, so I've already switched to dummy names `codec0`, `codec1`, ...

## Test Plan

Tested on an internal project, fixes those compilation errors.