### PR TITLE
#96: Add tapiro authentication (closes #96)

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
@@ -14,7 +14,7 @@ object Http4sMeta {
     http4sEndpoints: List[Defn.Val],
     routes: Term,
   ) => {
-    val tapirEndpoints = q"val endpoints = $endpointsName.create()"
+    val tapirEndpoints = q"val endpoints = $endpointsName.create[AuthToken]()"
     val httpsEndpointsName = Term.Name(s"${controllerName.syntax}Http4sEndpoints")
     q"""
     package ${`package`} {
@@ -27,7 +27,7 @@ object Http4sMeta {
       import sttp.tapir.Codec.{ JsonCodec, PlainCodec }
 
       object $httpsEndpointsName {
-        def routes[F[_]: Sync](controller: $controllerName[F])(..$implicits): HttpRoutes[F] = {
+        def routes[F[_]: Sync, AuthToken](controller: $controllerName[F, AuthToken])(..$implicits): HttpRoutes[F] = {
           ..${tapirEndpoints +: http4sEndpoints :+ routes}
         }
       }


### PR DESCRIPTION
Closes #96

This is more a proposal rather than a pr. I ended up here just following types.
I'm forcing the controller to be something like (AuthToken is usually a string):

```scala
trait Controller[F[_], AuthToken] {
  @query
  def ghetto(
    at: AuthToken,
  ): F[Either[Errore, SpittyCash]]
}
```

The generate code looks like this:
```scala
...

object ControllerHttp4sEndpoints {
  def routes[F[_]: Sync, AuthToken](controller: Controller[F, AuthToken])(
      implicit codec0: JsonCodec[SpittyCash],
      codec1: JsonCodec[Errore.Errorone],
      codec2: JsonCodec[Errore.Errorino],
      codec3: PlainCodec[AuthToken],
      cs: ContextShift[F]
  ): HttpRoutes[F] = {
    val endpoints = ControllerEndpoints.create[AuthToken]()
    val ghetto = endpoints.ghetto.toRoutes(controller.ghetto)
    NonEmptyList(ghetto, List()).reduceK
  }
}
```

```scala
...

trait ControllerEndpoints[AuthToken] {
  val ghetto: Endpoint[AuthToken, Errore, SpittyCash, Nothing]
}

object ControllerEndpoints {

  def create[AuthToken](
      statusCodes: String => StatusCode = _ => StatusCode.UnprocessableEntity
  )(
      implicit ...
      codec3: PlainCodec[AuthToken]
  ) = new ControllerEndpoints[AuthToken] {
    override val ghetto: Endpoint[AuthToken, Errore, SpittyCash, Nothing] =
      endpoint.get
        .in("ghetto")
        .in(header[AuthToken]("Authorization"))
        .errorOut(
            ...
        )
        .out(jsonBody[SpittyCash])
  }
}
```

The good thing is that you can pass a custom AuthToken decoder.
Makes sense to you? 