### PR TITLE
#108: Allow discarding route error models via config (closes #108)

### DIFF
--- a/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/Metarpheus.scala
+++ b/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/Metarpheus.scala
@@ -15,7 +15,7 @@ object Metarpheus {
     val parsed = files.map(File(_).parse[Source].get)
     extractors
       .extractFullAPI(parsed = parsed)
-      .stripUnusedModels(config.modelsForciblyInUse)
+      .stripUnusedModels(config.modelsForciblyInUse, config.discardRouteErrorModels)
   }
 
 }

--- a/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/config.scala
+++ b/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/config.scala
@@ -2,7 +2,8 @@ package io.buildo.metarpheus
 package core
 
 case class Config(
-  modelsForciblyInUse: Set[String] = Set.empty
+  modelsForciblyInUse: Set[String] = Set.empty,
+  discardRouteErrorModels: Boolean = false,
 )
 
 object Config {

--- a/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/intermediate/intermediate.scala
+++ b/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/intermediate/intermediate.scala
@@ -82,7 +82,10 @@ object Route {
 
 case class API(models: List[Model], routes: List[Route]) {
 
-  def stripUnusedModels(modelsForciblyInUse: Set[String] = Set.empty): API = {
+  def stripUnusedModels(
+    modelsForciblyInUse: Set[String] = Set.empty,
+    discardRouteErrorModels: Boolean = false,
+  ): API = {
     val modelsInUse: Set[Type] = {
       routes.flatMap { route =>
         route.route.collect {
@@ -90,7 +93,7 @@ case class API(models: List[Model], routes: List[Route]) {
         } ++
           route.params.map(_.tpe) ++
           List(route.returns) ++
-          route.error.toList ++
+          (if (discardRouteErrorModels) Nil else route.error.toList) ++
           route.body.map(b => List(b.tpe)).getOrElse(Nil)
       }
     }.toSet

--- a/metarpheus/core/src/test/scala/io.buildo.metarpheus/core/extractors/ApiSuite.scala
+++ b/metarpheus/core/src/test/scala/io.buildo.metarpheus/core/extractors/ApiSuite.scala
@@ -30,6 +30,16 @@ class ApiSuite extends FunSuite {
     }.isDefined)
 
     assert(api.models.collectFirst {
+      case TaggedUnion(
+          "CreateCampingError",
+          _,
+          _,
+          _,
+          ) =>
+        ()
+    }.isDefined)
+
+    assert(api.models.collectFirst {
       case CaseClass(
           "IgnoreMe",
           _,
@@ -42,4 +52,32 @@ class ApiSuite extends FunSuite {
     }.isEmpty)
   }
 
+  test("extract used models, discarding error models") {
+    import intermediate._
+
+    val api = extractFullAPI(parsed)
+      .stripUnusedModels(Common.modelsForciblyInUse, discardRouteErrorModels = true)
+
+    assert(api.models.collectFirst {
+      case TaggedUnion(
+          "CreateCampingError",
+          _,
+          _,
+          _,
+          ) =>
+        ()
+    }.isEmpty)
+
+    assert(api.models.collectFirst {
+      case CaseClass(
+          "Camping",
+          _,
+          _,
+          _,
+          _,
+          _,
+          ) =>
+        ()
+    }.isDefined)
+  }
 }

--- a/metarpheus/jsFacade/src/main/scala/io.buildo.metarpheus/core/JSFacade.scala
+++ b/metarpheus/jsFacade/src/main/scala/io.buildo.metarpheus/core/JSFacade.scala
@@ -15,6 +15,7 @@ object JSFacade {
 
   trait JSConfig extends js.Object {
     val modelsForciblyInUse: js.UndefOr[js.Array[String]]
+    val discardRouteErrorModel: js.UndefOr[Boolean]
   }
 
   @JSExportTopLevel("run")


### PR DESCRIPTION
Closes #108

Added a config key to discard route error models. By default, it is false, that is, we do not discard them. If true, models that appear in route error types are not considered as being in use.

## Test Plan

I've added a test to check that the model is discarded.