### PR TITLE
metarpheus NPM release 2.1.0

### DIFF
--- a/metarpheus/jsFacade/npm/README.md
+++ b/metarpheus/jsFacade/npm/README.md
@@ -11,6 +11,7 @@ where:
 - `paths` is a list of **absolute** paths to analyze (they can be files or directories)
 - `config` [optional] is a configuration with the following (optional) keys:
   - `modelsForciblyInUse`: a list of models that are included even if unused by the exposed API.
+  - `discardRouteErrorModels` (default `false`): set to `true` to discard models that are only used for route error types
 
 and `API` is an object composed by two fields:
 

--- a/metarpheus/jsFacade/npm/package.json
+++ b/metarpheus/jsFacade/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metarpheus",
   "main": "index.js",
-  "version": "1.3.6",
+  "version": "2.1.0",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
Version increase + README update for the metarpheus NPM package

The last released version was 2.0.0 (though the version increase had not been pushed).
This is a minor release since it adds an additional optional configuration key.

(I've already created the release on NPM.)