### PR TITLE
Remove tapir endpoint output's need of string codecs

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
@@ -19,8 +19,8 @@ object Meta {
           route.body.map(_.tpe) :+
           route.returns)
     }.distinct
-    //no json codec for Unit, AuthToken in tapir
-      .filter(t => typeNameString(t) != "Unit")
+      .filter(t => typeNameString(t) != "Unit") //no json codec for Unit in tapir
+      .filter(t => typeNameString(t) != "String")
       .filter(t => typeNameString(t) != "AuthToken")
       .map(toScalametaType)
       ++ taggedUnionErrorMembers(routes))

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -147,18 +147,26 @@ object TapirMeta {
       },
     )
 
-  private[this] val withOutput = (endpoint: meta.Term, returnType: MetarpheusType) => {
-    if (typeNameString(returnType) == "Unit") endpoint
-    else Term.Apply(
-      Term.Select(endpoint, Term.Name("out")),
-      List(
-        Term.ApplyType(
-          Term.Name("jsonBody"),
-          List(toScalametaType(returnType)),
-        ),
-      ),
-    )
-  }
+  private[this] val withOutput = (endpoint: meta.Term, returnType: MetarpheusType) =>
+    typeNameString(returnType) match {
+      case "Unit" =>
+        endpoint
+      case "String" =>
+        Term.Apply(
+          Term.Select(endpoint, Term.Name("out")),
+          List(Term.Name("stringBody")),
+        )
+      case _ =>
+        Term.Apply(
+          Term.Select(endpoint, Term.Name("out")),
+          List(
+            Term.ApplyType(
+              Term.Name("jsonBody"),
+              List(toScalametaType(returnType)),
+            ),
+          ),
+        )
+    }
 
   private[this] val withParam = (endpoint: meta.Term, param: RouteParam) => {
     val noDesc =


### PR DESCRIPTION
Related to https://github.com/buildo/retro/issues/180

/cc @calippo 