### PR TITLE
#203: Wrap POST body as in wiro (closes #203)

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/AkkaHttpMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/AkkaHttpMeta.scala
@@ -41,26 +41,24 @@ object AkkaHttpMeta {
     q"pathPrefix($pathName) { List(..$rest).foldLeft[Route]($first)(_ ~ _) }"
   }
 
-  val endpoints = (routes: List[Route]) =>
+  val endpoints = (routes: List[TapiroRoute]) =>
     routes.map { route =>
-      val name = Term.Name(route.name.last)
+      val name = Term.Name(route.route.name.last)
       val endpointsName = q"endpoints.$name"
       val controllersName = q"controller.$name"
       val controllerContent =
         route.method match {
-          case "get" =>
-            route.params.length match {
+          case RouteMethod.GET =>
+            route.route.params.length match {
               case 0 => q"_ => $controllersName()"
               case 1 => controllersName
               case _ => q"($controllersName _).tupled"
             }
-          case "post" =>
-            val fields = route.params
+          case RouteMethod.POST =>
+            val fields = route.route.params
               .filterNot(_.tpe == MetarpheusType.Name("AuthToken"))
               .map(p => Term.Name(p.name.getOrElse(Meta.typeNameString(p.tpe))))
             q"x => $controllersName(..${fields.map(f => q"x.$f")})"
-          case _ =>
-            throw new Exception("method not supported")
         }
       val toRoute = q"$endpointsName.toRoute($controllerContent)"
       q"val ${Pat.Var(name)} = $toRoute"

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/AkkaHttpMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/AkkaHttpMeta.scala
@@ -1,6 +1,6 @@
 package io.buildo.tapiro
 
-import io.buildo.metarpheus.core.intermediate.{Route, Type => MetarpheusType}
+import io.buildo.metarpheus.core.intermediate.Route
 
 import scala.meta._
 
@@ -44,23 +44,7 @@ object AkkaHttpMeta {
   val endpoints = (routes: List[TapiroRoute]) =>
     routes.map { route =>
       val name = Term.Name(route.route.name.last)
-      val endpointsName = q"endpoints.$name"
-      val controllersName = q"controller.$name"
-      val controllerContent =
-        route.method match {
-          case RouteMethod.GET =>
-            route.route.params.length match {
-              case 0 => q"_ => $controllersName()"
-              case 1 => controllersName
-              case _ => q"($controllersName _).tupled"
-            }
-          case RouteMethod.POST =>
-            val fields = route.route.params
-              .filterNot(_.tpe == MetarpheusType.Name("AuthToken"))
-              .map(p => Term.Name(p.name.getOrElse(Meta.typeNameString(p.tpe))))
-            q"x => $controllersName(..${fields.map(f => q"x.$f")})"
-        }
-      val toRoute = q"$endpointsName.toRoute($controllerContent)"
-      q"val ${Pat.Var(name)} = $toRoute"
+      val endpointImpl = Meta.toEndpointImplementation(route)
+      q"val ${Pat.Var(name)} = endpoints.$name.toRoute($endpointImpl)"
     }
 }

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/AkkaHttpMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/AkkaHttpMeta.scala
@@ -49,7 +49,8 @@ object AkkaHttpMeta {
       val controllerContent =
         route.method match {
           case "get" =>
-            if (route.params.length <= 1) controllersName
+            if (route.params.length == 0) q"_ => $controllersName()"
+            else if (route.params.length == 1) controllersName
             else Term.Select(Term.Eta(controllersName), Term.Name("tupled"))
           case "post" =>
             val fields = route.params

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/AkkaHttpMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/AkkaHttpMeta.scala
@@ -1,6 +1,6 @@
 package io.buildo.tapiro
 
-import io.buildo.metarpheus.core.intermediate.Route
+import io.buildo.metarpheus.core.intermediate.{Route, Type => MetarpheusType}
 
 import scala.meta._
 
@@ -19,11 +19,12 @@ object AkkaHttpMeta {
     q"""
     package ${`package`} {
       ..${imports.toList.map(i => q"import $i._")}
+      import akka.http.scaladsl.server._
+      import akka.http.scaladsl.server.Directives._
+      import io.circe.{ Decoder, Encoder }
       import sttp.tapir.server.akkahttp._
       import sttp.tapir.Codec.{ JsonCodec, PlainCodec }
       import sttp.model.StatusCode
-      import akka.http.scaladsl.server._
-      import akka.http.scaladsl.server.Directives._
 
       object $httpEndpointsName {
         def routes[AuthToken](controller: $controllerName[AuthToken], statusCodes: String => StatusCode = _ => StatusCode.UnprocessableEntity)(..$implicits): Route = {
@@ -41,16 +42,25 @@ object AkkaHttpMeta {
   }
 
   val endpoints = (routes: List[Route]) =>
-    routes.flatMap { route =>
+    routes.map { route =>
       val name = Term.Name(route.name.last)
       val endpointsName = Term.Select(Term.Name("endpoints"), name)
       val controllersName = Term.Select(Term.Name("controller"), name)
       val controllerContent =
-        if (route.params.length <= 1) Some(controllersName)
-        else Some(Term.Select(Term.Eta(controllersName), Term.Name("tupled")))
-      controllerContent.map { content =>
-        val toRoute = Term.Apply(Term.Select(endpointsName, Term.Name("toRoute")), List(content))
-        q"val ${Pat.Var(name)} = $toRoute"
-      }
+        route.method match {
+          case "get" =>
+            if (route.params.length <= 1) controllersName
+            else Term.Select(Term.Eta(controllersName), Term.Name("tupled"))
+          case "post" =>
+            val fields = route.params
+              .filterNot(_.tpe == MetarpheusType.Name("AuthToken"))
+              .map(p => Term.Name(p.name.getOrElse(Meta.typeNameString(p.tpe))))
+            q"x => $controllersName(..${fields.map(f => q"x.$f")})"
+          case _ =>
+            throw new Exception("method not supported")
+        }
+      val toRoute =
+        Term.Apply(Term.Select(endpointsName, Term.Name("toRoute")), List(controllerContent))
+      q"val ${Pat.Var(name)} = $toRoute"
     }
 }

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
@@ -42,7 +42,7 @@ object Http4sMeta {
     val first = Term.Name(head.name.last)
     val rest = tail.map(a => Term.Name(a.name.last))
     val route: Lit.String = Lit.String("/" + pathName.value)
-    q"Router($route -> NonEmptyList($first, List(..$rest)).reduceK)"
+    q"Router($route -> NonEmptyList.of($first, ..$rest).reduceK)"
   }
 
   val endpoints = (routes: List[TapiroRoute]) =>

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
@@ -53,7 +53,8 @@ object Http4sMeta {
       val controllerContent =
         route.method match {
           case "get" =>
-            if (route.params.length <= 1) controllersName
+            if (route.params.length == 0) q"_ => $controllersName()"
+            else if (route.params.length == 1) controllersName
             else Term.Select(Term.Eta(controllersName), Term.Name("tupled"))
           case "post" =>
             val fields = route.params

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
@@ -17,7 +17,6 @@ object Meta {
           route.returns)
     }.distinct
       .filter(t => typeNameString(t) != "Unit") //no json codec for Unit in tapir
-      .filter(t => typeNameString(t) != "String")
       .map(toScalametaType)
       ++ taggedUnionErrorMembers(routes))
       .map(t => t"JsonCodec[$t]")

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
@@ -25,7 +25,7 @@ object Meta {
         (method match {
           case RouteMethod.GET => route.params.map(_.tpe)
           case _               => Nil
-        }) ++ route.params.map(_.tpe).filter(typeNameString(_) == "AuthToken")
+        }) ++ route.params.map(_.tpe).filter(isAuthToken)
     }.distinct.map(t => t"PlainCodec[${toScalametaType(t)}]")
     val circeCodecs = routes.flatMap {
       case TapiroRoute(route, method, _) =>

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -70,10 +70,10 @@ object TapirMeta {
           .filter(_.tpe == MetarpheusType.Name(authTokenName))
           .map(t => toScalametaType(t.tpe))
           .headOption
-        val outputType = postInputType(route.route)
+        val inputType = postInputType(route.route)
         authTokenType match {
-          case Some(t) => Type.Tuple(List(outputType, t))
-          case None    => outputType
+          case Some(t) => Type.Tuple(List(inputType, t))
+          case None    => inputType
         }
     }
     val error = toScalametaType(route.error match {

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -168,11 +168,6 @@ object TapirMeta {
     typeNameString(returnType) match {
       case "Unit" =>
         endpoint
-      case "String" =>
-        Term.Apply(
-          Term.Select(endpoint, Term.Name("out")),
-          List(Term.Name("stringBody")),
-        )
       case _ =>
         Term.Apply(
           Term.Select(endpoint, Term.Name("out")),

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -1,6 +1,11 @@
 package io.buildo.tapiro
 
-import io.buildo.metarpheus.core.intermediate.{RouteParam, TaggedUnion, Type => MetarpheusType}
+import io.buildo.metarpheus.core.intermediate.{
+  Route,
+  RouteParam,
+  TaggedUnion,
+  Type => MetarpheusType,
+}
 
 import scala.meta._
 
@@ -15,11 +20,16 @@ object TapirMeta {
     tapirEndpointsName: Term.Name,
     implicits: List[Term.Param],
     body: List[Defn.Val],
+    postInputClassDeclarations: List[Defn.Class],
+    postInputCodecDeclarations: List[Defn.Val],
   ) =>
     q"""
     package ${`package`} {
       ..${imports.toList.map(i => q"import $i._")}
+      import io.circe.{ Decoder, Encoder }
+      import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
       import sttp.tapir._
+      import sttp.tapir.json.circe._
       import sttp.tapir.Codec.{ JsonCodec, PlainCodec }
       import sttp.model.StatusCode
 
@@ -32,10 +42,13 @@ object TapirMeta {
       Type.Name(tapirEndpointsName.value),
       Name.Anonymous(),
       Nil,
-    )}[AuthToken] { ..${body.map(
-      d => d.copy(mods = mod"override" :: d.mods),
-    )} }
+    )}[AuthToken] {
+          ..${postInputCodecDeclarations}
+          ..${body.map(d => d.copy(mods = mod"override" :: d.mods))}
+        }
       }
+
+      ..${postInputClassDeclarations}
     }
     """
 
@@ -44,11 +57,18 @@ object TapirMeta {
 
   private[this] val endpointType = (route: TapiroRoute) => {
     val returnType = toScalametaType(route.route.returns)
-    val argsList = route.route.params.map(p => toScalametaType(p.tpe))
-    val argsType = argsList match {
-      case Nil         => Type.Name("Unit")
-      case head :: Nil => head
-      case l           => Type.Tuple(l)
+    val argsType = route.route.method match {
+      case "get" =>
+        val argsList = route.route.params.map(p => toScalametaType(p.tpe))
+        argsList match {
+          case Nil         => Type.Name("Unit")
+          case head :: Nil => head
+          case l           => Type.Tuple(l)
+        }
+      case "post" =>
+        postInputType(route.route)
+      case _ =>
+        throw new Exception("method not supported")
     }
     val error = toScalametaType(route.error match {
       case TapiroRouteError.TaggedUnionError(t) => MetarpheusType.Name(t.name)
@@ -63,8 +83,8 @@ object TapirMeta {
         .Select(Term.Select(Term.Name("endpoint"), Term.Name(route.route.method)), Term.Name("in")),
       List(Lit.String(route.route.name.tail.mkString)),
     )
-    val (auth, params) = route.route.params.partition(_.tpe == MetarpheusType.Name(authTokenName))
-    val endpointsWithParams = withParams(basicEndpoint, route.route.method, params)
+    val (auth, _) = route.route.params.partition(_.tpe == MetarpheusType.Name(authTokenName))
+    val endpointsWithParams = withParams(basicEndpoint, route.route)
     withOutput(
       withError(
         auth match {
@@ -91,25 +111,22 @@ object TapirMeta {
       ),
     )
 
-  private[this] val withParams =
-    (endpoint: meta.Term, method: String, params: List[RouteParam]) => {
-      method match {
-        case "get" =>
-          params.foldLeft(endpoint) { (acc, param) =>
-            withParam(acc, param)
-          }
-        case "post" =>
-          params.foldLeft(endpoint) { (acc, param) =>
-            withBody(acc, param.tpe)
-          }
-        case _ => throw new Exception("method not supported")
-      },
-    }
+  private[this] val withParams = (endpoint: meta.Term, route: Route) => {
+    route.method match {
+      case "get" =>
+        route.params.foldLeft(endpoint) { (acc, param) =>
+          withParam(acc, param)
+        }
+      case "post" =>
+        withBody(endpoint, route)
+      case _ => throw new Exception("method not supported")
+    },
+  }
 
-  private[this] val withBody = (endpoint: meta.Term, tpe: MetarpheusType) => {
+  private[this] val withBody = (endpoint: meta.Term, route: Route) => {
     Term.Apply(
       Term.Select(endpoint, Term.Name("in")),
-      List(Term.ApplyType(Term.Name("jsonBody"), List(toScalametaType(tpe)))),
+      List(Term.ApplyType(Term.Name("jsonBody"), List(postInputType(route)))),
     ),
   }
 
@@ -117,19 +134,20 @@ object TapirMeta {
     (endpoints: meta.Term, routeError: TapiroRouteError) =>
       routeError match {
         case TapiroRouteError.OtherError(t) if typeNameString(t) == "Unit" => endpoints
-        case _ => Term.Apply(
-          Term.Select(endpoints, Term.Name("errorOut")),
-          List(
-            routeError match {
-              case TapiroRouteError.TaggedUnionError(taggedUnion) =>
-                listErrors(taggedUnion)
-              case TapiroRouteError.OtherError(MetarpheusType.Name("String")) =>
-                Term.Name("stringBody")
-              case TapiroRouteError.OtherError(t) =>
-                Term.ApplyType(Term.Name("jsonBody"), List(toScalametaType(t)))
-            },
-          ),
-        )
+        case _ =>
+          Term.Apply(
+            Term.Select(endpoints, Term.Name("errorOut")),
+            List(
+              routeError match {
+                case TapiroRouteError.TaggedUnionError(taggedUnion) =>
+                  listErrors(taggedUnion)
+                case TapiroRouteError.OtherError(MetarpheusType.Name("String")) =>
+                  Term.Name("stringBody")
+                case TapiroRouteError.OtherError(t) =>
+                  Term.ApplyType(Term.Name("jsonBody"), List(toScalametaType(t)))
+              },
+            ),
+          )
       }
 
   private[this] val listErrors = (taggedUnion: TaggedUnion) =>
@@ -184,5 +202,30 @@ object TapirMeta {
       case Some(desc) =>
         Term.Apply(Term.Select(noDesc, Term.Name("description")), List(Lit.String(desc)))
     }
+  }
+
+  private[this] val postInputType = (route: Route) =>
+    Type.Name(route.name.tail.mkString.capitalize + "RequestPayload")
+
+  val routeClassDeclarations = (route: TapiroRoute) =>
+    if (route.route.method == "post") {
+      val params = route.route.params
+        .filterNot(_.tpe == MetarpheusType.Name(authTokenName))
+        .map { p =>
+          param"${Term.Name(p.name.getOrElse(typeNameString(p.tpe)))}: ${toScalametaType(p.tpe)}"
+        }
+      List(q"case class ${postInputType(route.route)}(..$params)")
+    } else Nil
+
+  val routeCodecDeclarations: TapiroRoute => List[Defn.Val] = (route: TapiroRoute) => {
+    val mkDeclaration = (s: String) => {
+      val name = Pat.Var(Term.Name(route.route.name.tail.mkString + "RequestPayload" + s))
+      val tpe = postInputType(route.route)
+      val fun = Term.Name("derive" + s)
+      q"implicit val $name : ${Type.Name(s)}[$tpe] = $fun"
+    }
+    if (route.route.method == "post") {
+      List("Decoder", "Encoder").map(mkDeclaration)
+    } else Nil
   }
 }

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Util.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Util.scala
@@ -125,6 +125,8 @@ class Util() {
         Term.Name(tapirEndpointsName),
         Meta.codecsImplicits(routes),
         routes.map(TapirMeta.routeToTapirEndpoint),
+        routes.flatMap(TapirMeta.routeClassDeclarations),
+        routes.flatMap(TapirMeta.routeCodecDeclarations),
       ),
     )
   }

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Util.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Util.scala
@@ -25,13 +25,19 @@ object Server {
   case object NoServer extends Server
 }
 
-sealed trait TapiroRouteError
-object TapiroRouteError {
-  case class TaggedUnionError(taggedUnion: TaggedUnion) extends TapiroRouteError
-  case class OtherError(`type`: MetarpheusType) extends TapiroRouteError
+sealed trait RouteError
+object RouteError {
+  case class TaggedUnionError(taggedUnion: TaggedUnion) extends RouteError
+  case class OtherError(`type`: MetarpheusType) extends RouteError
 }
 
-case class TapiroRoute(route: Route, error: TapiroRouteError)
+sealed trait RouteMethod
+object RouteMethod {
+  case object GET extends RouteMethod
+  case object POST extends RouteMethod
+}
+
+case class TapiroRoute(route: Route, method: RouteMethod, error: RouteError)
 
 class Util() {
   import Formatter.format
@@ -49,9 +55,8 @@ class Util() {
       case Some(nonEmptyPackage) =>
         val config = Config(Set.empty)
         val models = Metarpheus.run(modelsPaths, config).models
-        val routes: List[TapiroRoute] = Metarpheus.run(routesPaths, config).routes.map { route =>
-          TapiroRoute(route, routeError(route, models))
-        }
+        val routes: List[TapiroRoute] =
+          Metarpheus.run(routesPaths, config).routes.map(toTapiroRoute(models))
         val controllersRoutes =
           routes.groupBy(
             route => (route.route.controllerType, route.route.pathName),
@@ -153,7 +158,7 @@ class Util() {
               Term.Name(tapirEndpointsName),
               Term.Name(httpEndpointsName),
               Meta.codecsImplicits(tapiroRoutes) :+ param"implicit cs: ContextShift[F]",
-              Http4sMeta.endpoints(routes),
+              Http4sMeta.endpoints(tapiroRoutes),
               Http4sMeta.routes(Lit.String(pathName), head, tail),
             ),
           ),
@@ -183,7 +188,7 @@ class Util() {
               Term.Name(tapirEndpointsName),
               Term.Name(httpEndpointsName),
               Meta.codecsImplicits(tapiroRoutes),
-              AkkaHttpMeta.endpoints(routes),
+              AkkaHttpMeta.endpoints(tapiroRoutes),
               AkkaHttpMeta.routes(Lit.String(pathName), head, tail),
             ),
           ),

--- a/tapiro/core/src/test/scala/io/buildo/tapiro/TapiroSuite.scala
+++ b/tapiro/core/src/test/scala/io/buildo/tapiro/TapiroSuite.scala
@@ -5,7 +5,7 @@ import java.nio.file.Files
 class TapiroSuite extends munit.FunSuite {
 
   check(
-    "tapir and http4s endpoints",
+    "tapir-http4s-endpoints",
     Server.Http4s,
     "src/main/scala/schools/endpoints",
     """
@@ -157,16 +157,14 @@ class TapiroSuite extends munit.FunSuite {
       |    })
       |    val read = endpoints.read.toRoutes(controller.read)
       |    val list = endpoints.list.toRoutes(_ => controller.list())
-      |    Router(
-      |      "/SchoolController" -> NonEmptyList(create, List(read, list)).reduceK
-      |    )
+      |    Router("/SchoolController" -> NonEmptyList.of(create, read, list).reduceK)
       |  }
       |}
       |""".stripMargin,
   )
 
   check(
-    "akkaHttp endpoints",
+    "akkaHttp-endpoints",
     Server.AkkaHttp,
     "src/main/scala/schools/endpoints",
     """

--- a/tapiro/sbt-tapiro/src/sbt-test/sbt-tapiro/simple/test
+++ b/tapiro/sbt-tapiro/src/sbt-test/sbt-tapiro/simple/test
@@ -10,4 +10,4 @@ $ exists "src/main/scala/endpoints/ExampleControllerHttpEndpoints.scala"
 # check that the endpoints respond as expected
 # NOTE(gabro): the single quotes surrounding the commands are a workaround for https://github.com/sbt/sbt/issues/4870
 > 'curlExpect -s -X GET  localhost:8080/ExampleController/queryExample?intParam=1&stringParam=abc               {"name":"abc","double":1.0}'
-> 'curlExpect -s -X POST localhost:8080/ExampleController/commandExample -d "{\"name\":\"abc\",\"double\":1.0}" abc'
+> 'curlExpect -s -X POST localhost:8080/ExampleController/commandExample -d "{\"body\": {\"name\":\"abc\",\"double\":1.0}}" "\"abc\""'


### PR DESCRIPTION
Closes #203

- Implement wrapping for POST
- Fix GET routes without parameters
- Also revert 0a856a8 to fix encoding of `String` output (see https://github.com/buildo/retro/issues/180#issuecomment-604483453 and later comments)
- Introduce an enumerated type for route method (GET vs POST)

Notes:

- The wrapper classes are generated in the tapir endpoints file.
- To ensure that they have instances for `JsonCodec`, I've added an import of `import sttp.tapir.json.circe._` to that file (so it can generate `JsonCodec` instances given Circe `Encoder` and `Decoder`) and added the Circe semiauto derivation of the `Encoder` and `Decoder`, adding implicit parameters of `Encoder` and `Decoder` for field names.
- Not very nice: in the implicits we're now mixing tapir `JsonCodec`/`PlainCodec` with circe `Encoder`/`Decoder`, it would be maybe nicer to always require `JsonCodec` and be able to derive the `JsonCodec` for the case class from those of the fields, but I couldn't find a way to do it.
- It's also not nice that we need `Encoder`, but tapir always expects both to be able to describe clients I think.

For example, for the controller
```scala
@path("test")
trait TestController[F[_], AuthToken] {
  @command
  def pusho(x: Obj1, y: Obj2): F[Either[Error1, String]]
}

case class Obj1(name: String)
case class Obj2(name: String)
```
we generate the tapir endpoints
```scala
trait TestTapirEndpoints[AuthToken] {
  val pusho: Endpoint[PushoRequestPayload, Error1, String, Nothing]
}

object TestTapirEndpoints {

  def create[AuthToken](statusCodes: String => StatusCode)(
      implicit codec0: JsonCodec[Error1],
      codec1: JsonCodec[String],
      codec2: Decoder[Obj1],
      codec3: Encoder[Obj1],
      codec4: Decoder[Obj2],
      codec5: Encoder[Obj2]
  ) = new TestTapirEndpoints[AuthToken] {
    implicit val pushoRequestPayloadDecoder: Decoder[PushoRequestPayload] =
      deriveDecoder
    implicit val pushoRequestPayloadEncoder: Encoder[PushoRequestPayload] =
      deriveEncoder
    override val pusho: Endpoint[PushoRequestPayload, Error1, String, Nothing] =
      endpoint.post
        .in("pusho")
        .in(jsonBody[PushoRequestPayload])
        .errorOut(jsonBody[Error1])
        .out(jsonBody[String])
  }
}

case class PushoRequestPayload(x: Obj1, y: Obj2)
```
and the http4s endpoints
```scala
object TestHttpEndpoints {
  def routes[F[_]: Sync, AuthToken](
      controller: TestController[F, AuthToken],
      statusCodes: String => StatusCode = _ => StatusCode.UnprocessableEntity
  )(
      implicit codec0: JsonCodec[Error1],
      codec1: JsonCodec[String],
      codec2: Decoder[Obj1],
      codec3: Encoder[Obj1],
      codec4: Decoder[Obj2],
      codec5: Encoder[Obj2],
      cs: ContextShift[F]
  ): HttpRoutes[F] = {
    val endpoints = TestTapirEndpoints.create[AuthToken](statusCodes)
    val pusho = endpoints.pusho.toRoutes(x => controller.pusho(x.x, x.y))
    Router("/test" -> NonEmptyList(pusho, List()).reduceK)
  }
}
```

## Test Plan

Tested on a small example project