### PR TITLE
Make imports in generated files predictable

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -25,7 +25,7 @@ object TapirMeta {
   ) =>
     q"""
     package ${`package`} {
-      ..${imports.toList.map(i => q"import $i._")}
+      ..${imports.toList.sortWith(_.toString < _.toString).map(i => q"import $i._")}
       import io.circe.{ Decoder, Encoder }
       import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
       import sttp.tapir._


### PR DESCRIPTION
The import list is manipulated as a set. Let's sort it before printing