### PR TITLE
#349: Tapiro generation bug when there are duplicate names for commands in different controllers

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Util.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Util.scala
@@ -129,7 +129,7 @@ class Util() {
         requiredPackages.toSet.map(Meta.packageFromList),
         Term.Name(tapirEndpointsName),
         Meta.codecsImplicits(routes),
-        routes.map(TapirMeta.routeToTapirEndpoint),
+        routes.map(TapirMeta.routeToTapirEndpoint(Term.Name(tapirEndpointsName))),
         routes.flatMap(TapirMeta.routeClassDeclarations),
         routes.flatMap(TapirMeta.routeCodecDeclarations),
       ),

--- a/tapiro/core/src/test/scala/io/buildo/tapiro/TapiroSuite.scala
+++ b/tapiro/core/src/test/scala/io/buildo/tapiro/TapiroSuite.scala
@@ -53,7 +53,7 @@ class TapiroSuite extends munit.FunSuite {
       |trait SchoolControllerTapirEndpoints[AuthToken] {
       |
       |  val create: Endpoint[
-      |    (CreateRequestPayload, AuthToken),
+      |    (SchoolControllerTapirEndpoints.CreateRequestPayload, AuthToken),
       |    SchoolCreateError,
       |    Unit,
       |    Nothing
@@ -79,7 +79,7 @@ class TapiroSuite extends munit.FunSuite {
       |    implicit val createRequestPayloadEncoder: Encoder[CreateRequestPayload] =
       |      deriveEncoder
       |    override val create: Endpoint[
-      |      (CreateRequestPayload, AuthToken),
+      |      (SchoolControllerTapirEndpoints.CreateRequestPayload, AuthToken),
       |      SchoolCreateError,
       |      Unit,
       |      Nothing
@@ -111,8 +111,8 @@ class TapiroSuite extends munit.FunSuite {
       |    override val list: Endpoint[Unit, Unit, List[School], Nothing] =
       |      endpoint.get.in("list").out(jsonBody[List[School]])
       |  }
+      |  case class CreateRequestPayload(school: School)
       |}
-      |case class CreateRequestPayload(school: School)
       |
       |/src/main/scala/schools/endpoints/SchoolControllerHttpEndpoints.scala
       |//----------------------------------------------------------


### PR DESCRIPTION
Closes #349

The PR moves the `*RequestPayload` classes generated for commands inside the `*TapirEndpoints` object. This ensures that classes used in distinct endpoints do not clash if they have the same name (i.e. if the commands have the same name).

Note that this might be breaking: if a project references these classes (e.g. to use the endpoints as client and not only as server), the imports or qualified names should be updated.

## Test Plan

Updated the automatic tests.

Tested on two internal projects, including the one which exhibited the bug because two controllers had a `create` command.