### PR TITLE
Move Jakarta Mail namespace from javax to jakarta as per Jakarta 2.x

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -343,7 +343,7 @@ jobs:
     passed:
       - sbt-buildo
       - enumero
-      # - mailo
+      - mailo
       - toctoc
       - metarpheus
       - tapiro

--- a/mailo/src/main/scala/mailo/http/MailClient.scala
+++ b/mailo/src/main/scala/mailo/http/MailClient.scala
@@ -1,6 +1,6 @@
 package mailo.http
 
-import javax.mail.internet.MimeMessage
+import jakarta.mail.internet.MimeMessage
 import mailo.MailRefinedContent._
 import mailo.{Attachment, MailError, MailResponse}
 

--- a/mailo/src/main/scala/mailo/http/MailgunClient.scala
+++ b/mailo/src/main/scala/mailo/http/MailgunClient.scala
@@ -13,8 +13,8 @@ import akka.stream.scaladsl.Source
 import akka.actor.ActorSystem
 
 import scala.concurrent.{ExecutionContext, Future}
-import javax.mail.Message.RecipientType
-import javax.mail.internet.MimeMessage
+import jakarta.mail.Message.RecipientType
+import jakarta.mail.internet.MimeMessage
 
 import com.typesafe.config.{Config, ConfigFactory}
 

--- a/mailo/src/main/scala/mailo/http/SMTPClient.scala
+++ b/mailo/src/main/scala/mailo/http/SMTPClient.scala
@@ -4,12 +4,12 @@ import java.util.{Properties, UUID}
 
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.LazyLogging
-import javax.mail.internet.{InternetAddress, MimeMessage}
+import jakarta.mail.internet.{InternetAddress, MimeMessage}
 import mailo.{Attachment, MailError, MailRefinedContent, MailResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util._
-import javax.mail._
+import jakarta.mail._
 import mailo.MailRefinedContent.{HTMLContent, TEXTContent}
 import mailo.http.MailClientError.{BadRequest, UnknownError}
 import scala.util.control.NonFatal

--- a/mailo/src/main/scala/mailo/http/SendinblueClient.scala
+++ b/mailo/src/main/scala/mailo/http/SendinblueClient.scala
@@ -17,7 +17,7 @@ import MailRefinedContent._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import javax.mail.internet.MimeMessage
+import jakarta.mail.internet.MimeMessage
 
 class SendinblueClient(
   implicit conf: Config = ConfigFactory.load(),


### PR DESCRIPTION
Jakarta Mail 2.0.0 moved the package namespace from `javax.mail` to `jakarta.mail`, which currently leads to a failing build.