### PR TITLE
Fix compile errors in docs due to updated tapir

### DIFF
--- a/docs/tapiro/introduction.md
+++ b/docs/tapiro/introduction.md
@@ -65,7 +65,6 @@ Here is how to run the server:
 ```scala mdoc
 import org.http4s.server.blaze._
 import org.http4s.implicits._
-import cats.implicits._
 
 object Main extends IOApp {
   val catsImpl = Cats.create[IO]
@@ -112,7 +111,7 @@ def decodeAuth(s: String): DecodeResult[CustomAuth] = {
 
 def encodeAuth(auth: CustomAuth): String = auth.token
 
-implicit val authCodec: PlainCodec[CustomAuth] = Codec.stringPlainCodecUtf8
+implicit val authCodec: PlainCodec[CustomAuth] = Codec.string
   .mapDecode(decodeAuth)(encodeAuth)
 ```
 

--- a/docs/tapiro/migrate.md
+++ b/docs/tapiro/migrate.md
@@ -24,7 +24,7 @@ import sttp.tapir.Codec._
 
 case class Auth(token: String) //should be imported as wiro.Auth instead
 
-implicit val authCodec: PlainCodec[Auth] = Codec.stringPlainCodecUtf8
+implicit val authCodec: PlainCodec[Auth] = Codec.string
   .mapDecode(decodeAuth)(encodeAuth)
 
 def decodeAuth(s: String): DecodeResult[Auth] = {


### PR DESCRIPTION
Fix two compile errors due to updated tapir version changing the `Codec` type.