### PR TITLE
CI pipeline improvements

### DIFF
--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -1,0 +1,17 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: buildo/scala-sbt-alpine
+    tag: 8u201_2.12.11_1.3.9
+
+inputs:
+  - name: retro
+
+run:
+  dir: retro
+  path: sbt
+  args:
+    - -batch
+    - docs/mdoc

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -88,6 +88,17 @@ resources:
       - project
       - tapiro
 
+- type: pull-request
+  name: docs-pr
+  icon: source-pull
+  source:
+    repository: buildo/retro
+    access_token: ((github-token))
+    paths:
+      - build.sbt
+      - project
+      - docs
+
 - name: postgres
   type: docker-image
   icon: docker
@@ -342,6 +353,32 @@ jobs:
         path: retro
         status: success
         context: tapiro
+
+- name: docs-pr
+  plan:
+  - get: retro
+    resource: docs-pr
+    trigger: true
+    version: every
+  - put: docs-pr
+    params:
+      path: retro
+      status: pending
+      context: docs
+  - task: build-docs
+    file: retro/ci/docs.yml
+  on_failure:
+    put: docs-pr
+    params:
+      path: retro
+      status: failure
+      context: docs
+  on_success:
+    put: docs-pr
+    params:
+      path: retro
+      status: success
+      context: docs
 
 - name: release
   plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -169,6 +169,14 @@ jobs:
   - task: test
     file: retro/tapiro/ci/test.yml
 
+- name: docs
+  plan:
+  - get: retro
+    resource: master
+    trigger: true
+  - task: build-docs
+    file: retro/ci/docs.yml
+
 - name: sbt-buildo-pr
   plan:
   - get: retro
@@ -347,6 +355,7 @@ jobs:
       - toctoc
       - metarpheus
       - tapiro
+      - docs
   - get: tag
     trigger: true
   - task: release on Sonatype

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,6 +4,11 @@ resource_types:
   source:
     repository: teliaoss/github-pr-resource
 
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+
 resources:
 - type: git
   name: master
@@ -120,6 +125,23 @@ resources:
     repository: buildo/scala-sbt-alpine
     tag: 8u201_2.12.11_1.3.9
 
+- name: slack-buildo
+  type: slack-notification
+  icon: slack
+  source:
+    url: ((buildo-slack-hook))
+
+
+__put_slack_failed_job: &slack_failure
+  put: slack-buildo
+  params:
+    channel: "#backends"
+    text: |
+      The build of $BUILD_JOB_NAME failed :cry:
+      See: $ATC_EXTERNAL_URL/builds/$BUILD_ID
+  inputs: []
+
+
 jobs:
 
 - name: sbt-buildo
@@ -129,6 +151,8 @@ jobs:
     trigger: true
   - task: compile
     file: retro/sbt-buildo/ci/compile.yml
+  on_failure:
+    <<: *slack_failure
 
 - name: enumero
   plan:
@@ -137,6 +161,8 @@ jobs:
     trigger: true
   - task: test
     file: retro/enumero/ci/test.yml
+  on_failure:
+    <<: *slack_failure
 
 - name: mailo
   plan:
@@ -145,6 +171,8 @@ jobs:
     trigger: true
   - task: test
     file: retro/mailo/ci/test.yml
+  on_failure:
+    <<: *slack_failure
 
 - name: toctoc
   plan:
@@ -163,6 +191,8 @@ jobs:
   - task: test
     file: retro/toctoc/ci/test.yml
     privileged: true
+  on_failure:
+    <<: *slack_failure
 
 - name: metarpheus
   plan:
@@ -171,6 +201,8 @@ jobs:
     trigger: true
   - task: test
     file: retro/metarpheus/ci/test.yml
+  on_failure:
+    <<: *slack_failure
 
 - name: tapiro
   plan:
@@ -179,6 +211,8 @@ jobs:
     trigger: true
   - task: test
     file: retro/tapiro/ci/test.yml
+  on_failure:
+    <<: *slack_failure
 
 - name: docs
   plan:
@@ -187,6 +221,8 @@ jobs:
     trigger: true
   - task: build-docs
     file: retro/ci/docs.yml
+  on_failure:
+    <<: *slack_failure
 
 - name: sbt-buildo-pr
   plan:
@@ -403,4 +439,13 @@ jobs:
       PGP_SECRET: ((sonatype_pgp_secret_key))
       SONATYPE_USERNAME: ((sonatype_username))
       SONATYPE_PASSWORD: ((sonatype_password))
+  on_success:
+    put: slack-buildo
+    params:
+      channel: "#backends"
+      text: |
+        :tada: A new release has been successfully performed
+    inputs: []
+  on_failure:
+    <<: *slack_failure
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -201,18 +201,18 @@ jobs:
       context: sbt-buildo
   - task: compile
     file: retro/sbt-buildo/ci/compile.yml
-    on_failure:
-      put: sbt-buildo-pr
-      params:
-        path: retro
-        status: failure
-        context: sbt-buildo
-    on_success:
-      put: sbt-buildo-pr
-      params:
-        path: retro
-        status: success
-        context: sbt-buildo
+  on_failure:
+    put: sbt-buildo-pr
+    params:
+      path: retro
+      status: failure
+      context: sbt-buildo
+  on_success:
+    put: sbt-buildo-pr
+    params:
+      path: retro
+      status: success
+      context: sbt-buildo
 
 - name: enumero-pr
   plan:
@@ -227,18 +227,18 @@ jobs:
       context: enumero
   - task: test
     file: retro/enumero/ci/test.yml
-    on_failure:
-      put: enumero-pr
-      params:
-        path: retro
-        status: failure
-        context: enumero
-    on_success:
-      put: enumero-pr
-      params:
-        path: retro
-        status: success
-        context: enumero
+  on_failure:
+    put: enumero-pr
+    params:
+      path: retro
+      status: failure
+      context: enumero
+  on_success:
+    put: enumero-pr
+    params:
+      path: retro
+      status: success
+      context: enumero
 
 - name: mailo-pr
   plan:
@@ -253,18 +253,18 @@ jobs:
       context: mailo
   - task: test
     file: retro/mailo/ci/test.yml
-    on_failure:
-      put: mailo-pr
-      params:
-        path: retro
-        status: failure
-        context: mailo
-    on_success:
-      put: mailo-pr
-      params:
-        path: retro
-        status: success
-        context: mailo
+  on_failure:
+    put: mailo-pr
+    params:
+      path: retro
+      status: failure
+      context: mailo
+  on_success:
+    put: mailo-pr
+    params:
+      path: retro
+      status: success
+      context: mailo
 
 - name: toctoc-pr
   plan:
@@ -289,18 +289,18 @@ jobs:
   - task: test
     file: retro/toctoc/ci/test.yml
     privileged: true
-    on_failure:
-      put: toctoc-pr
-      params:
-        path: retro
-        status: failure
-        context: toctoc
-    on_success:
-      put: toctoc-pr
-      params:
-        path: retro
-        status: success
-        context: toctoc
+  on_failure:
+    put: toctoc-pr
+    params:
+      path: retro
+      status: failure
+      context: toctoc
+  on_success:
+    put: toctoc-pr
+    params:
+      path: retro
+      status: success
+      context: toctoc
 
 - name: metarpheus-pr
   plan:
@@ -315,18 +315,18 @@ jobs:
       context: metarpheus
   - task: test
     file: retro/metarpheus/ci/test.yml
-    on_failure:
-      put: metarpheus-pr
-      params:
-        path: retro
-        status: failure
-        context: metarpheus
-    on_success:
-      put: metarpheus-pr
-      params:
-        path: retro
-        status: success
-        context: metarpheus
+  on_failure:
+    put: metarpheus-pr
+    params:
+      path: retro
+      status: failure
+      context: metarpheus
+  on_success:
+    put: metarpheus-pr
+    params:
+      path: retro
+      status: success
+      context: metarpheus
 
 - name: tapiro-pr
   plan:
@@ -341,18 +341,18 @@ jobs:
       context: tapiro
   - task: test
     file: retro/tapiro/ci/test.yml
-    on_failure:
-      put: tapiro-pr
-      params:
-        path: retro
-        status: failure
-        context: tapiro
-    on_success:
-      put: tapiro-pr
-      params:
-        path: retro
-        status: success
-        context: tapiro
+  on_failure:
+    put: tapiro-pr
+    params:
+      path: retro
+      status: failure
+      context: tapiro
+  on_success:
+    put: tapiro-pr
+    params:
+      path: retro
+      status: success
+      context: tapiro
 
 - name: docs-pr
   plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -194,18 +194,21 @@ jobs:
 
 - name: toctoc
   plan:
-  - get: retro
-    resource: master
-    trigger: true
-  - get: postgres
-    params:
-      save: true
-  - get: mysql
-    params:
-      save: true
-  - get: scala-sbt
-    params:
-      save: true
+  - in_parallel:
+      fail_fast: true
+      steps:
+      - get: retro
+        resource: master
+        trigger: true
+      - get: postgres
+        params:
+          save: true
+      - get: mysql
+        params:
+          save: true
+      - get: scala-sbt
+        params:
+          save: true
   - task: test
     file: retro/toctoc/ci/test.yml
     privileged: true
@@ -322,19 +325,22 @@ jobs:
 
 - name: toctoc-pr
   plan:
-  - get: retro
-    resource: toctoc-pr
-    trigger: true
-    version: every
-  - get: postgres
-    params:
-      save: true
-  - get: mysql
-    params:
-      save: true
-  - get: scala-sbt
-    params:
-      save: true
+  - in_parallel:
+      fail_fast: true
+      steps:
+      - get: retro
+        resource: toctoc-pr
+        trigger: true
+        version: every
+      - get: postgres
+        params:
+          save: true
+      - get: mysql
+        params:
+          save: true
+      - get: scala-sbt
+        params:
+          save: true
   - put: toctoc-pr
     params:
       path: retro
@@ -436,19 +442,22 @@ jobs:
 
 - name: release
   plan:
-  - get: retro
-    resource: master
-    trigger: true
-    passed:
-      - sbt-buildo
-      - enumero
-      - mailo
-      - toctoc
-      - metarpheus
-      - tapiro
-      - docs
-  - get: tag
-    trigger: true
+  - in_parallel:
+      fail_fast: true
+      steps:
+      - get: retro
+        resource: master
+        trigger: true
+        passed:
+          - sbt-buildo
+          - enumero
+          - mailo
+          - toctoc
+          - metarpheus
+          - tapiro
+          - docs
+      - get: tag
+        trigger: true
   - task: release-on-sonatype
     file: retro/ci/release.yml
     params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,6 +13,8 @@ resources:
 - type: git
   name: master
   icon: github-circle
+  webhook_token: 0gd4XZNL4Y94zYDLql3C
+  check_every: 30m
   source:
     uri: https://github.com/buildo/retro.git
     branch: master
@@ -21,6 +23,8 @@ resources:
 - type: git
   name: tag
   icon: tag
+  webhook_token: 0gd4XZNL4Y94zYDLql3C
+  check_every: 30m
   source:
     uri: https://github.com/buildo/retro.git
     branch: master
@@ -29,6 +33,8 @@ resources:
 - type: pull-request
   name: sbt-buildo-pr
   icon: source-pull
+  webhook_token: 0gd4XZNL4Y94zYDLql3C
+  check_every: 30m
   source:
     repository: buildo/retro
     access_token: ((github-token))
@@ -40,6 +46,8 @@ resources:
 - type: pull-request
   name: enumero-pr
   icon: source-pull
+  webhook_token: 0gd4XZNL4Y94zYDLql3C
+  check_every: 30m
   source:
     repository: buildo/retro
     access_token: ((github-token))
@@ -51,6 +59,8 @@ resources:
 - type: pull-request
   name: mailo-pr
   icon: source-pull
+  webhook_token: 0gd4XZNL4Y94zYDLql3C
+  check_every: 30m
   source:
     repository: buildo/retro
     access_token: ((github-token))
@@ -63,6 +73,8 @@ resources:
 - type: pull-request
   name: toctoc-pr
   icon: source-pull
+  webhook_token: 0gd4XZNL4Y94zYDLql3C
+  check_every: 30m
   source:
     repository: buildo/retro
     access_token: ((github-token))
@@ -74,6 +86,8 @@ resources:
 - type: pull-request
   name: metarpheus-pr
   icon: source-pull
+  webhook_token: 0gd4XZNL4Y94zYDLql3C
+  check_every: 30m
   source:
     repository: buildo/retro
     access_token: ((github-token))
@@ -85,6 +99,8 @@ resources:
 - type: pull-request
   name: tapiro-pr
   icon: source-pull
+  webhook_token: 0gd4XZNL4Y94zYDLql3C
+  check_every: 30m
   source:
     repository: buildo/retro
     access_token: ((github-token))
@@ -96,6 +112,8 @@ resources:
 - type: pull-request
   name: docs-pr
   icon: source-pull
+  webhook_token: 0gd4XZNL4Y94zYDLql3C
+  check_every: 30m
   source:
     repository: buildo/retro
     access_token: ((github-token))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -431,7 +431,7 @@ jobs:
       - docs
   - get: tag
     trigger: true
-  - task: release on Sonatype
+  - task: release-on-sonatype
     file: retro/ci/release.yml
     params:
       GITHUB_DEPLOY_KEY: ((private-key))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,11 +1,13 @@
 resource_types:
 - name: pull-request
   type: docker-image
+  check_every: 24h
   source:
     repository: teliaoss/github-pr-resource
 
 - name: slack-notification
   type: docker-image
+  check_every: 24h
   source:
     repository: cfcommunity/slack-notification-resource
 


### PR DESCRIPTION
A bunch of small improvements / cleanups / optimizations to the CI pipeline:
 * explicitly build docs on master and PRs;
 * `on_success` and `on_failure` at job level for PRs;
 * slack notifications for failures on master and successful releases;
 * webhooks for Git and PR resources;
 * a few other optimizations.