### PR TITLE
Fix docs builds

### DIFF
--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -3,8 +3,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: buildo/scala-sbt-alpine
-    tag: 8u201_2.12.11_1.3.9
+    repository: hseeberger/scala-sbt
+    tag: 8u242_1.3.8_2.12.10
 
 inputs:
   - name: retro

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -123,6 +123,7 @@ resources:
       - build.sbt
       - project
       - docs
+      - ci/docs.yml
 
 - name: postgres
   type: docker-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -145,6 +145,13 @@ resources:
     repository: buildo/scala-sbt-alpine
     tag: 8u201_2.12.11_1.3.9
 
+- name: hseeberger-scala-sbt
+  type: docker-image
+  icon: docker
+  source:
+    repository: hseeberger/scala-sbt
+    tag: 8u242_1.3.8_2.12.10
+
 - name: slack-buildo
   type: slack-notification
   icon: slack
@@ -239,10 +246,15 @@ jobs:
 
 - name: docs
   plan:
-  - get: retro
-    resource: master
-    trigger: true
+  - in_parallel:
+      fail_fast: true
+      steps:
+      - get: retro
+        resource: master
+        trigger: true
+      - get: hseeberger-scala-sbt
   - task: build-docs
+    image: hseeberger-scala-sbt
     file: retro/ci/docs.yml
   on_failure:
     <<: *slack_failure
@@ -418,16 +430,21 @@ jobs:
 
 - name: docs-pr
   plan:
-  - get: retro
-    resource: docs-pr
-    trigger: true
-    version: every
+  - in_parallel:
+      fail_fast: true
+      steps:
+      - get: retro
+        resource: docs-pr
+        trigger: true
+        version: every
+      - get: hseeberger-scala-sbt
   - put: docs-pr
     params:
       path: retro
       status: pending
       context: docs
   - task: build-docs
+    image: hseeberger-scala-sbt
     file: retro/ci/docs.yml
   on_failure:
     put: docs-pr
@@ -460,7 +477,9 @@ jobs:
           - docs
       - get: tag
         trigger: true
+      - get: hseeberger-scala-sbt
   - task: release-on-sonatype
+    image: hseeberger-scala-sbt
     file: retro/ci/release.yml
     params:
       GITHUB_DEPLOY_KEY: ((private-key))


### PR DESCRIPTION
Use the same build container for docs build jobs and release. This is due to the fact that building docs in `buildo/scala-sbt-alpine:8u201_2.12.11_1.3.9` leads to PlantUML's NPE.

Also explicitly set dependencies on `hseeberger/scala-sbt` at pipeline level, avoiding potential version inconsistencies via `image` field.