### PR TITLE
New tapiro imports

### DIFF
--- a/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/Metarpheus.scala
+++ b/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/Metarpheus.scala
@@ -15,7 +15,7 @@ object Metarpheus {
       .stripUnusedModels(config.modelsForciblyInUse, config.discardRouteErrorModels)
   }
 
-def parseFiles(paths: List[String]) : List[Source] = {
+  def parseFiles(paths: List[String]) : List[Source] = {
     val files = paths
       .flatMap(path => PlatformFileIO.listAllFilesRecursively(AbsolutePath(path)))
       .filter(_.toString.endsWith(".scala"))

--- a/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/Metarpheus.scala
+++ b/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/Metarpheus.scala
@@ -9,13 +9,17 @@ import scala.meta.internal.io.PlatformFileIO
 object Metarpheus {
 
   def run(paths: List[String], config: Config): intermediate.API = {
-    val files = paths
-      .flatMap(path => PlatformFileIO.listAllFilesRecursively(AbsolutePath(path)))
-      .filter(_.toString.endsWith(".scala"))
-    val parsed = files.map(File(_).parse[Source].get)
+    val parsed = parseFiles(paths)
     extractors
       .extractFullAPI(parsed = parsed)
       .stripUnusedModels(config.modelsForciblyInUse, config.discardRouteErrorModels)
   }
+
+def parseFiles(paths: List[String]) : List[Source] = {
+    val files = paths
+      .flatMap(path => PlatformFileIO.listAllFilesRecursively(AbsolutePath(path)))
+      .filter(_.toString.endsWith(".scala"))
+    files.map(File(_).parse[Source].get)
+}
 
 }

--- a/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/extractors/package.scala
+++ b/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/extractors/package.scala
@@ -19,6 +19,11 @@ package object extractors {
     intermediate.API(models, routes)
   }
 
+  def extractImports(source: scala.meta.Source): List[scala.meta.Import] =
+    source.collect {
+      case imp: scala.meta.Import => imp
+  }
+
   /**
     * Extract all terms from a sequence of applications of an infix operator
     * (which translates to nested `ApplyInfix`es).

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/AkkaHttpMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/AkkaHttpMeta.scala
@@ -7,7 +7,7 @@ import scala.meta._
 object AkkaHttpMeta {
   val `class` = (
     `package`: Term.Ref,
-    imports: Set[Term.Ref],
+    imports: Set[Import],
     controllerName: Type.Name,
     tapirEndpointsName: Term.Name,
     authTokenName: Type.Name,
@@ -21,7 +21,7 @@ object AkkaHttpMeta {
     val tapirEndpoints = q"val endpoints = $tapirEndpointsName.create[$authTokenName](statusCodes)"
     q"""
     package ${`package`} {
-      ..${imports.toList.sortWith(_.toString < _.toString).map(i => q"import $i._")}
+      ..${imports.toList.sortWith(_.toString < _.toString)}
       import akka.http.scaladsl.server._
       import akka.http.scaladsl.server.Directives._
       import io.circe.{ Decoder, Encoder }

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Http4sMeta.scala
@@ -7,7 +7,7 @@ import scala.meta._
 object Http4sMeta {
   val `class` = (
     `package`: Term.Ref,
-    imports: Set[Term.Ref],
+    imports: Set[Import],
     controllerName: Type.Name,
     tapirEndpointsName: Term.Name,
     authTokenName: Type.Name,
@@ -21,7 +21,7 @@ object Http4sMeta {
     val tapirEndpoints = q"val endpoints = $tapirEndpointsName.create[$authTokenName](statusCodes)"
     q"""
     package ${`package`} {
-      ..${imports.toList.sortWith(_.toString < _.toString).map(i => q"import $i._")}
+      ..${imports.toList.sortWith(_.toString < _.toString)}
       import cats.effect._
       import cats.implicits._
       import cats.data.NonEmptyList

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/Meta.scala
@@ -8,6 +8,29 @@ import scala.meta.contrib._
 import cats.data.NonEmptyList
 
 object Meta {
+
+  val controllerImports =(routes: List[TapiroRoute],imports: Set[Importer])  =>   {
+    val types = routes.flatMap(tr => tr.route.params.map(r=> r.tpe) ++ (if (tr.route.error.isDefined) List(tr.route.error.get,tr.route.returns) else  List(tr.route.returns))) 
+    val typeNameList = types.flatMap(typeNameExtractor(_)).toSet
+    val (wildcardImportList,importList) = imports.collect{
+      case i : Importer if i.syntax.endsWith("._") => List(i)
+      case Importer(ref,importees) => importees.filter(p=> typeNameList.contains(p.syntax)).map(p=> Importer(ref,List(p)))
+    }.flatten.partition(_.syntax.endsWith("._"))
+    val importers = if (importList.flatMap(i=> typeNameList.diff(i.importees.map(_.syntax).toSet)).isEmpty) importList else  {
+      val controllerPackageStrings = routes.map(r=> s"import ${r.route.controllerPackage.mkString(".")}._")
+      val controllerPackage : List[Import] =controllerPackageStrings.flatMap(_.parse[Source].getOrElse(Source(List())).tree.children).collect{case i: Import => i}
+      controllerPackage.flatMap(cp=> cp.importers) ++ wildcardImportList ++ importList
+    }
+    val result= importers.map(i=>Import(List(i)))
+    deduplicate(result.toList).toSet
+  } : Set[Import]
+
+  def typeNameExtractor (tpe : MetarpheusType) : Set[String]=
+    tpe match {
+      case MetarpheusType.Name(name) => Set(name)
+      case MetarpheusType.Apply(head,args) => (head :: args.map(typeNameExtractor(_)).flatten.toList).toSet
+    }
+
   val codecsImplicits = (routes: List[TapiroRoute], authTokenName: String) => {
     val notUnit = (t: MetarpheusType) => t != MetarpheusType.Name("Unit")
     val toDecoder = (t: Type) => t"Decoder[${extractListType(t)}]"
@@ -44,10 +67,10 @@ object Meta {
     case _ => t
   }
 
-  private[this] val deduplicate: List[Type] => List[Type] = (ts: List[Type]) =>
+  private[this] def deduplicate[A<:Tree](ts: List[A]): List[A] =
     ts match {
       case Nil          => Nil
-      case head :: tail => head :: deduplicate(tail.filter(!_.isEqual(head)))
+      case head :: tail => head :: deduplicate(tail.filter(!_.syntax.equals(head.syntax)))
     }
 
   private[this] val isAuthToken = (t: MetarpheusType, authTokenName: String) => t == MetarpheusType.Name(authTokenName)

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -14,7 +14,7 @@ object TapirMeta {
 
   val `class` = (
     `package`: Term.Ref,
-    imports: Set[Term.Ref],
+    imports: Set[Import],
     tapirEndpointsName: Term.Name,
     authTokenName: Type.Name,
     implicits: List[Term.Param],
@@ -26,7 +26,7 @@ object TapirMeta {
       Type.Param(List(), authTokenName, List(), Type.Bounds(None, None), List(), List())
     q"""
     package ${`package`} {
-      ..${imports.toList.sortWith(_.toString < _.toString).map(i => q"import $i._")}
+      ..${imports.toList.sortWith(_.toString < _.toString)}
       import io.circe.{ Decoder, Encoder }
       import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
       import sttp.tapir._


### PR DESCRIPTION
The idea is to generate imports from controller imports instead of model packages.
All the  “._” imports present in the route paths, will be included if is not possible to find a specific import for a type in a root.
This will lead to some unused imports (that can be removed with Scalafix), but adds support to types not present in the model (such UUID,LocalDateTime, etc)