### PR TITLE
support option in post

### DIFF
--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -226,7 +226,7 @@ object TapirMeta {
         val params = route.route.params
           .filterNot(_.tpe == MetarpheusType.Name(authTokenName))
           .map { p =>
-            param"${Term.Name(p.name.getOrElse(typeNameString(p.tpe)))}: ${metarpheusTypeToScalametaType(p.tpe)}"
+            param"${Term.Name(p.name.getOrElse(typeNameString(p.tpe)))}: ${routeParamToScalametaType(p)}"
           }
         List(q"case class ${postInputType(route.route)}(..$params)")
       case RouteMethod.GET =>


### PR DESCRIPTION
Post params of type Option[T] were handled as params of type T in RequestPayload class.