### PR TITLE
Upgrade to Scala 2.13.6 and fix CI release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 import org.scalajs.sbtplugin.ScalaJSCrossVersion
 
 val scala212 = "2.12.13"
-val scala213 = "2.13.5"
+val scala213 = "2.13.6"
 val scala3 = "3.0.1"
 
 inThisBuild(

--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: hseeberger/scala-sbt
-    tag: 8u282_1.5.4_2.13.5
+    tag: 8u282_1.5.4_2.13.6
 
 inputs:
   - name: retro

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -616,6 +616,9 @@ jobs:
                 - metarpheus
                 - tapiro
                 - docs
+                - wiro
+                - scalafmt
+                - java-time-circe-codecs
             - get: tag
               trigger: true
             - get: hseeberger-scala-sbt

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -179,14 +179,14 @@ resources:
     icon: docker
     source:
       repository: buildo/scala-sbt-alpine
-      tag: 8_2.13.5_1.5.4
+      tag: 8_2.13.6_1.5.4
 
   - name: hseeberger-scala-sbt
     type: docker-image
     icon: docker
     source:
       repository: hseeberger/scala-sbt
-      tag: 8u282_1.5.4_2.13.5
+      tag: 8u282_1.5.4_2.13.6
 
   - name: slack-buildo
     type: slack-notification

--- a/ci/release.yml
+++ b/ci/release.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: hseeberger/scala-sbt
-    tag: 8u282_1.5.4_2.13.5
+    tag: 8u282_1.5.4_2.13.6
 
 inputs:
   - name: retro

--- a/enumero/ci/test.yml
+++ b/enumero/ci/test.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: buildo/scala-sbt-alpine
-    tag: 8_2.13.5_1.5.4
+    tag: 8_2.13.6_1.5.4
 
 inputs:
   - name: retro

--- a/javaTimeCirceCodecs/ci/test.yml
+++ b/javaTimeCirceCodecs/ci/test.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: buildo/scala-sbt-alpine
-    tag: 8_2.13.5_1.5.4
+    tag: 8_2.13.6_1.5.4
 
 inputs:
   - name: retro

--- a/mailo/ci/test.yml
+++ b/mailo/ci/test.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: buildo/scala-sbt-alpine
-    tag: 8_2.13.5_1.5.4
+    tag: 8_2.13.6_1.5.4
 
 inputs:
   - name: retro

--- a/metarpheus/ci/test.yml
+++ b/metarpheus/ci/test.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: buildo/scala-sbt-alpine
-    tag: 8_2.13.5_1.5.4
+    tag: 8_2.13.6_1.5.4
 
 inputs:
   - name: retro

--- a/sbt-buildo/ci/compile.yml
+++ b/sbt-buildo/ci/compile.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: buildo/scala-sbt-alpine
-    tag: 8_2.13.5_1.5.4
+    tag: 8_2.13.6_1.5.4
 
 inputs:
   - name: retro

--- a/tapiro/ci/test.yml
+++ b/tapiro/ci/test.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: buildo/scala-sbt-alpine
-    tag: 8_2.13.5_1.5.4
+    tag: 8_2.13.6_1.5.4
 
 inputs:
   - name: retro

--- a/toctoc/ci/docker-compose.yml
+++ b/toctoc/ci/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   tests:
-    image: buildo/scala-sbt-alpine:8_2.13.5_1.5.4
+    image: buildo/scala-sbt-alpine:8_2.13.6_1.5.4
     container_name: tests
     environment:
       DB_USER: postgres

--- a/wiro/ci/test.yml
+++ b/wiro/ci/test.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: buildo/scala-sbt-alpine
-    tag: 8_2.13.5_1.5.4
+    tag: 8_2.13.6_1.5.4
 
 inputs:
   - name: retro


### PR DESCRIPTION
Currently the docs and release CI tasks are broken because they're looking for the tag 8u282_1.5.4_2.13.5 of hseeberger/scala-sbt which doesn't exist.

The PR updates to Scala 2.13.6 and updates CI images.