### PR TITLE
Fix 'method too large' compile error in tapiro endpoints

### DIFF
--- a/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/extractors/package.scala
+++ b/metarpheus/core/src/main/scala/io.buildo.metarpheus/core/extractors/package.scala
@@ -19,22 +19,6 @@ package object extractors {
     intermediate.API(models, routes)
   }
 
-  /**
-    * Extract all terms from a sequence of applications of an infix operator
-    * (which translates to nested `ApplyInfix`es).
-    * e.g. getAllInfix(t1 + t2 + t3 + t4, "+") results in List(t1, t2, t3, t4)
-    */
-  private[extractors] def getAllInfix(ainfix: Term, op: String): List[Term] = {
-    import scala.meta._
-    ainfix match {
-      case Term.ApplyInfix(subinfix: Term.ApplyInfix, Term.Name(`op`), Nil, List(term: Term)) =>
-        getAllInfix(subinfix, `op`) :+ term
-      case Term.ApplyInfix(term1: Term, Term.Name(`op`), Nil, List(term2: Term)) =>
-        term1 :: term2 :: Nil
-      case term: Term => term :: Nil
-    }
-  }
-
   /*
    * Convert a scala-meta representation of a type to a metarpheus
    * intermediate representation

--- a/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
+++ b/tapiro/core/src/main/scala/io/buildo/tapiro/TapirMeta.scala
@@ -45,7 +45,7 @@ object TapirMeta {
       Nil,
     )}[$authTokenName] {
           ..${postInputCodecDeclarations}
-          ..${body.map(d => d.copy(mods = mod"override" :: d.mods))}
+          ..${body.map(d => d.copy(mods = mod"override" :: mod"lazy" :: d.mods))}
         }
 
         ..${postInputClassDeclarations}

--- a/tapiro/core/src/test/scala/io/buildo/tapiro/TapiroSuite.scala
+++ b/tapiro/core/src/test/scala/io/buildo/tapiro/TapiroSuite.scala
@@ -78,7 +78,7 @@ class TapiroSuite extends munit.FunSuite {
       |      deriveDecoder
       |    implicit val createRequestPayloadEncoder: Encoder[CreateRequestPayload] =
       |      deriveEncoder
-      |    override val create: Endpoint[
+      |    override lazy val create: Endpoint[
       |      (SchoolControllerTapirEndpoints.CreateRequestPayload, Auth),
       |      SchoolCreateError,
       |      Unit,
@@ -95,7 +95,7 @@ class TapiroSuite extends munit.FunSuite {
       |          )
       |        )
       |      )
-      |    override val read: Endpoint[Long, SchoolReadError, School, Nothing] =
+      |    override lazy val read: Endpoint[Long, SchoolReadError, School, Nothing] =
       |      endpoint.get
       |        .in("read")
       |        .in(query[Long]("id"))
@@ -108,11 +108,11 @@ class TapiroSuite extends munit.FunSuite {
       |          )
       |        )
       |        .out(jsonBody[School])
-      |    override val list: Endpoint[List[School], Unit, List[School], Nothing] =
-      |      endpoint.get
-      |        .in("list")
-      |        .in(query[List[School]]("excludedSchools[]"))
-      |        .out(jsonBody[List[School]])
+      |    override lazy val list
+      |        : Endpoint[List[School], Unit, List[School], Nothing] = endpoint.get
+      |      .in("list")
+      |      .in(query[List[School]]("excludedSchools[]"))
+      |      .out(jsonBody[List[School]])
       |  }
       |  case class CreateRequestPayload(school: School)
       |}


### PR DESCRIPTION
Closes #425

Generate endpoints as `lazy val` instead of `val` to prevent 'method too large' errors when compiling them.

## Test Plan

Updated test + manual test on an internal project, where it solves the error.