### PR TITLE
sbt-buildo: Update kind-projector to support Scala 2.13.10

### DIFF
--- a/sbt-buildo/src/main/scala/buildo/ScalaSettingPlugin.scala
+++ b/sbt-buildo/src/main/scala/buildo/ScalaSettingPlugin.scala
@@ -68,7 +68,7 @@ object ScalaSettingPlugin extends AutoPlugin {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) =>
           compilerPlugin(
-            ("org.typelevel" % "kind-projector" % "0.13.1").cross(CrossVersion.full),
+            ("org.typelevel" % "kind-projector" % "0.13.2").cross(CrossVersion.full),
           ) :: Nil
         case _ => Nil
       }


### PR DESCRIPTION
Update kind-project to version 0.13.2 to support Scala 2.13.10 (version 0.13.1 is not published for 2.13.10)