### PR TITLE
mailo: change expected error from Sendinblue

### DIFF
--- a/mailo/src/test/scala/mailo/SendinblueSpec.scala
+++ b/mailo/src/test/scala/mailo/SendinblueSpec.scala
@@ -89,7 +89,7 @@ class SendinblueSpec extends munit.FunSuite {
           value,
           Left(
             http.MailClientError.UnknownError(
-              "{\"code\":\"missing_parameter\",\"message\":\"sender name is missing\"}",
+              "{\"code\":\"invalid_parameter\",\"message\":\"valid sender email required\"}\n",
             ),
           ),
         )


### PR DESCRIPTION
Sendinblue now returns a different error message for invalid sender, see failed CI build https://concourse.our.buildo.io/builds/10748699
<img width="1423" alt="Screenshot 2023-01-20 at 16 37 25" src="https://user-images.githubusercontent.com/5033362/213740671-f0474fc1-636f-4c30-807d-ebc957b86175.png">
