### PR TITLE
Use scala 3.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalajs.sbtplugin.ScalaJSCrossVersion
 
 val scala212 = "2.12.13"
 val scala213 = "2.13.6"
-val scala3 = "3.0.1"
+val scala3 = "3.3.1"
 
 inThisBuild(
   List(


### PR DESCRIPTION
This PR updates the scala 3 version that is used by the monorepo to `3.3.1`. This should solve the problems that made [this CI build](https://concourse.our.buildo.io/builds/16056763) fail.

## Tests
:white_check_mark: Launching crossCompilation with `+ compile` in sbt works fine now (it wasn't previously)