### PR TITLE
Use registry-image instead of docker-image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -163,6 +163,7 @@ resources:
   - name: postgres
     type: registry-image
     icon: docker
+    check_every: 24h
     source:
       repository: postgres
       tag: "16.1-alpine"
@@ -170,6 +171,7 @@ resources:
   - name: mysql
     type: registry-image
     icon: docker
+    check_every: 24h
     source:
       repository: mysql
       tag: "8"
@@ -177,6 +179,7 @@ resources:
   - name: scala-sbt
     type: registry-image
     icon: docker
+    check_every: 24h
     source:
       repository: buildo/scala-sbt-alpine
       tag: 8_2.13.6_1.5.5
@@ -184,6 +187,7 @@ resources:
   - name: hseeberger-scala-sbt
     type: registry-image
     icon: docker
+    check_every: 24h
     source:
       repository: hseeberger/scala-sbt
       tag: 8u282_1.5.5_2.13.6

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -161,28 +161,28 @@ resources:
         - ci/docs.yml
 
   - name: postgres
-    type: docker-image
+    type: registry-image
     icon: docker
     source:
       repository: postgres
       tag: "16.1-alpine"
 
   - name: mysql
-    type: docker-image
+    type: registry-image
     icon: docker
     source:
       repository: mysql
       tag: "8"
 
   - name: scala-sbt
-    type: docker-image
+    type: registry-image
     icon: docker
     source:
       repository: buildo/scala-sbt-alpine
       tag: 8_2.13.6_1.5.5
 
   - name: hseeberger-scala-sbt
-    type: docker-image
+    type: registry-image
     icon: docker
     source:
       repository: hseeberger/scala-sbt
@@ -243,14 +243,11 @@ jobs:
               resource: master
               trigger: true
             - get: postgres
-              params:
-                save: true
+              params: { format: oci }
             - get: mysql
-              params:
-                save: true
+              params: { format: oci }
             - get: scala-sbt
-              params:
-                save: true
+              params: { format: oci }
       - task: test
         file: retro/toctoc/ci/test.yml
         privileged: true
@@ -410,14 +407,11 @@ jobs:
               trigger: true
               version: every
             - get: postgres
-              params:
-                save: true
+              params: { format: oci }
             - get: mysql
-              params:
-                save: true
+              params: { format: oci }
             - get: scala-sbt
-              params:
-                save: true
+              params: { format: oci }
       - put: toctoc-pr
         params:
           path: retro

--- a/toctoc/ci/test.yml
+++ b/toctoc/ci/test.yml
@@ -22,14 +22,9 @@ run:
     - -ceux
     - |
       # Use images cached by concourse
-      docker load -i postgres/image
-      docker tag "$(cat postgres/image-id)" "$(cat postgres/repository):$(cat postgres/tag)"
-
-      docker load -i mysql/image
-      docker tag "$(cat mysql/image-id)" "$(cat mysql/repository):$(cat mysql/tag)"
-
-      docker load -i scala-sbt/image
-      docker tag "$(cat scala-sbt/image-id)" "$(cat scala-sbt/repository):$(cat scala-sbt/tag)"
+      docker load -i postgres/image.tar
+      docker load -i mysql/image.tar
+      docker load -i scala-sbt/image.tar
 
       # Run the tests container and its dependencies.
       export PROJECT_PATH="$PWD/retro"


### PR DESCRIPTION
This PR solves the issues with our pull-through cache not being able to retrieve postgres:16.1-alpine and mysql:8:
 * the issue arises with images published as OCI images
 * the docker-image resource performs a HEAD request for manifests but it does not support OCI images, thus lacking the media type "application/vnd.oci.image.index.v1+json" in the request's `Accept` header
 * the pull-through cache is probably overly strict and [returns a 404](https://github.com/distribution/distribution/blob/v2.8.1/registry/handlers/manifests.go#L176C14-L176C14) (relevant log excerpt: `level=error msg="response completed with error" err.code="manifest unknown" err.message="OCI index found, but accept header does not support OCI indexes" go.version=go1.17.3`)

The use of registry-image instead of docker-image solves the issue as registry-image provides the right Accept header contents (and it is a much modern resource-type). I also increased the refresh interval to 24 hours.

Tested by updating the pipeline manually and checking the tests run by this PR, which are successful.