### PR TITLE
Add a new error to AuthenticationError in toctoc

### DIFF
--- a/toctoc/core/src/main/scala/io.buildo.toctoc/core/authentication/AuthenticationError.scala
+++ b/toctoc/core/src/main/scala/io.buildo.toctoc/core/authentication/AuthenticationError.scala
@@ -7,6 +7,7 @@ object AuthenticationError {
   // toctoc error
   object InvalidCredential extends AuthenticationError
   object Forbidden extends AuthenticationError
+  object CredentialInsertError extends AuthenticationError
   // LDAP errors
   object LDAPOperationsError extends AuthenticationError
   object LDAPProtocolError extends AuthenticationError

--- a/toctoc/core/src/main/scala/io.buildo.toctoc/core/authentication/AuthenticationError.scala
+++ b/toctoc/core/src/main/scala/io.buildo.toctoc/core/authentication/AuthenticationError.scala
@@ -7,7 +7,7 @@ object AuthenticationError {
   // toctoc error
   object InvalidCredential extends AuthenticationError
   object Forbidden extends AuthenticationError
-  object CredentialInsertError extends AuthenticationError
+  object CredentialCreationFailed extends AuthenticationError
   // LDAP errors
   object LDAPOperationsError extends AuthenticationError
   object LDAPProtocolError extends AuthenticationError


### PR DESCRIPTION
This PR adds a new error to `AuthenticationError` in `toctoc`, that represents the situation when an insert for credentials in the database fails.