### PR TITLE
sbt-buildo: Update kind-projector to support Scala 2.13.18

### DIFF
--- a/sbt-buildo/src/main/scala/buildo/ScalaSettingPlugin.scala
+++ b/sbt-buildo/src/main/scala/buildo/ScalaSettingPlugin.scala
@@ -68,7 +68,7 @@ object ScalaSettingPlugin extends AutoPlugin {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) =>
           compilerPlugin(
-            ("org.typelevel" % "kind-projector" % "0.13.3").cross(CrossVersion.full),
+            ("org.typelevel" % "kind-projector" % "0.13.4").cross(CrossVersion.full),
           ) :: Nil
         case _ => Nil
       }


### PR DESCRIPTION
Update kind-projector to version 0.13.4 to support Scala 2.13.18 (version 0.13.3 is not published for 2.13.18)