### PR TITLE
docs: Fork mdoc run to avoid bgRun classloader issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -224,6 +224,7 @@ lazy val docs = project
     publish / skip := true,
     moduleName := "retro-docs",
     libraryDependencies ++= docsDependencies,
+    run / fork := true,
     mdocVariables := Map(
       "CIRCE_VERSION" -> V.circe,
       "AKKA_HTTP_VERSION" -> V.akkaHttp,


### PR DESCRIPTION
When running `docs/mdoc` via sbt's in-process `bgRunMain`, the isolated classloader fails to expose `scala.reflect.internal.SymbolTable.openPackageModule$default$2` to scala-compiler at runtime, even when both jars are 2.13.12 on the classpath. The exception is silently swallowed because it's thrown on a background thread, but the release pipeline then fails downstream when docusaurus tries to consume the empty `target/mdoc` directory.

Forcing `run / fork := true` for the docs project runs mdoc in a separate JVM with a clean classpath, sidestepping the issue.