### PR TITLE
ci-release: Scope publishTo per-project to route SNAPSHOTs away from local staging

### DIFF
--- a/project/CIRelease.scala
+++ b/project/CIRelease.scala
@@ -42,7 +42,7 @@ object CiReleasePlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[_]] = List(
     dynverSonatypeSnapshots := true,
-    ThisBuild / publishTo := {
+    publishTo := {
       val snaps = "https://central.sonatype.com/repository/maven-snapshots/"
       if (version.value.endsWith("-SNAPSHOT")) Some("central-snapshots".at(snaps))
       else localStaging.value


### PR DESCRIPTION
## Summary

`ThisBuild / publishTo := { version.value ... }` inside `projectSettings` is scoped incorrectly: the setting gets re-applied by every project, and `version.value` in the body resolves to the applying project's own version (not `ThisBuild / version`). The last project to apply wins, which means when one project has a non-SNAPSHOT version (e.g. `sbt-buildo` tagged as `0.11.13`), `ThisBuild / publishTo` ends up pointing at `localStaging` for every module — including the SNAPSHOT ones.

When `sonaRelease` then runs to promote the staging bundle, it finds SNAPSHOT artifacts in `target/sona-staging/` and aborts with:

```
[error] SNAPSHOTs are not supported on the Central Portal;
[error] configure ThisBuild / publishTo to publish directly to the central-snapshots.
```

This is why the four orphan GitHub releases from 2025-10-20 (`sbt-tapiro v0.2.1`, `sbt-tapiro v0.2.2`, `tapiro v0.2.1`, and the now-deleted `sbt-buildo v0.11.13`) never made it to Central Portal: tag and GH release were created, but the release job's `sonaRelease` step failed identically.

Dropping the `ThisBuild /` prefix makes `publishTo` a per-project setting and `version.value` resolves to each project's own version:

- `sbt-buildo` (version `0.11.13`, release) → `publishTo = localStaging` — goes through signed staging + `sonaRelease` promotion
- every other module (SNAPSHOT version) → `publishTo = central-snapshots` URL — published directly, bypassing staging

Verified locally by committing the fix on a test branch, moving the `sbt-buildo-v0.11.13` tag onto that commit, and inspecting `publishTo` for every module. The staging directory only collects `sbt-buildo`; SNAPSHOTs go straight to Central's snapshot repo. `sonaRelease` has nothing to complain about.
