### PR TITLE
ci-release: Skip snapshot publish when releasing to avoid sonaRelease mix

### DIFF
--- a/project/CIRelease.scala
+++ b/project/CIRelease.scala
@@ -78,7 +78,7 @@ object CiReleasePlugin extends AutoPlugin {
       }
 
       if (releaseProjects.length > 0) {
-        publishSignedCommands ::: publishCommands ::: "sonaRelease" :: currentState
+        publishSignedCommands ::: "sonaRelease" :: currentState
       } else {
         publishCommands ::: currentState
       }


### PR DESCRIPTION
## Summary

`sonaRelease` (sbt 1.10+ built-in for Central Portal) refuses to run when the build contains any SNAPSHOT artifact, with:

```
[error] SNAPSHOTs are not supported on the Central Portal;
[error] configure ThisBuild / publishTo to publish directly to the central-snapshots.
```

The previous ci-release flow, on a tagged commit, mixed both release and snapshot publications in a single sbt run:

```scala
publishSignedCommands ::: publishCommands ::: "sonaRelease" :: currentState
```

`publishSigned` for the tagged project (e.g. `sbt-buildo` on `sbt-buildo-v0.11.13`) went to `localStaging`, `publish` for all other modules (still SNAPSHOT) went to `central-snapshots` directly. But `ThisBuild / isSnapshot` remains `true` (the root `retro` version is `0.0.0+N-hash-SNAPSHOT`), and `sonaRelease` gates on that and refuses.

Dropping `publishCommands` from the release path isolates the flow:

- **Tagged commit** (e.g. `sbt-buildo-v0.11.13`): only `publishSigned` for release projects + `sonaRelease`. Nothing else goes out.
- **Master push** (no tag): unchanged — `publish` for all SNAPSHOT projects goes to `central-snapshots`.

Snapshots for the tagged commit itself are not published, but they get picked up by the next master push, which is acceptable (a tag commit is typically already on master anyway).

This is the third iteration on the October 2025 Central Portal migration — the previous two (buildo/retro#791, buildo/retro#790) fixed earlier layers of the same system. Locally I re-verified that `publishTo` per-project is correct; this PR completes the flow for `sonaRelease`.