### PR TITLE
ci-release: Skip cross-build prefix when crossScalaVersions is empty

### DIFF
--- a/project/CIRelease.scala
+++ b/project/CIRelease.scala
@@ -69,12 +69,14 @@ object CiReleasePlugin extends AutoPlugin {
         println(releaseProjects.map(_.project).mkString("  - ", "\n  - ", "\n"))
       }
 
+      def crossPrefix(projectRef: sbt.ProjectRef): String =
+        if (extracted.get(projectRef / crossScalaVersions).nonEmpty) "+" else ""
       val publishSignedCommands =
         releaseProjects.foldLeft(List.empty[String]) { (state, projectRef) =>
-          s"+${projectRef.project}/publishSigned" :: state
+          s"${crossPrefix(projectRef)}${projectRef.project}/publishSigned" :: state
         }
       val publishCommands = snapshotProjects.foldLeft(List.empty[String]) { (state, projectRef) =>
-        s"+${projectRef.project}/publish" :: state
+        s"${crossPrefix(projectRef)}${projectRef.project}/publish" :: state
       }
 
       if (releaseProjects.length > 0) {

--- a/project/CIRelease.scala
+++ b/project/CIRelease.scala
@@ -80,7 +80,16 @@ object CiReleasePlugin extends AutoPlugin {
       }
 
       if (releaseProjects.length > 0) {
-        publishSignedCommands ::: "sonaRelease" :: currentState
+        // `sonaRelease` (built-in in sbt 1.10+) reads `Keys.version` at the
+        // extracted's current ref. When invoked at the root, that's the root
+        // project's version — which, with per-project dynver, is a SNAPSHOT
+        // (no tag matches the root's empty `dynverTagPrefix`). sonaRelease's
+        // SNAPSHOT check then always fails. Inject a non-SNAPSHOT version on
+        // the root (any release project's version works — they've already
+        // been filtered to non-SNAPSHOT).
+        val releaseVersion = extracted.get(releaseProjects.head / version)
+        val setRootVersion = s"""set version := "$releaseVersion""""
+        publishSignedCommands ::: setRootVersion :: "sonaRelease" :: currentState
       } else {
         publishCommands ::: currentState
       }


### PR DESCRIPTION
## Summary

The release job for `sbt-buildo-v0.11.14` failed again — this time with the same `sonaRelease` SNAPSHOT error but for a different underlying reason: `+sbt-buildo/publishSigned` is a **silent no-op** on the Concourse worker. It runs, prints nothing, and exits successfully without signing or publishing anything. Then `sonaRelease` runs on an empty local staging and errors out.

Cause: `sbt-buildo` sets `crossScalaVersions := Nil` (build.sbt:39). In sbt 1.11.7, the `+` cross-build prefix with an empty `crossScalaVersions` list does NOT fall back to the single `scalaVersion` — it simply iterates over zero versions and does nothing. Verified locally:

- `sbt '+sbt-buildo/publishSigned'` → no output, exit 0, nothing published
- `sbt 'sbt-buildo/publishSigned'` → compiles, signs, publishes (fails only at signing because no local PGP key)

The snapshot flow that worked on October 23 wasn't publishing `sbt-buildo` via `+sbt-buildo/publish` — `sbt-buildo` was being published as a side effect of `+retro/publish` (aggregate root pulling in all sub-projects). The release flow doesn't go through the aggregate, so the direct invocation needs to not carry the `+` prefix when `crossScalaVersions` is empty.

Fix: conditionally prepend `+` only when the project has a non-empty `crossScalaVersions`. Verified locally with temporary debug println — for `sbt-buildo-v0.11.14` the command list becomes:

```
sbt-buildo/publishSigned
sonaRelease
```

(no `+`), and this invocation is known to actually execute `publishSigned`.